### PR TITLE
fix: handle HTTP 401 as valid deployment status in E2E workflow

### DIFF
--- a/.github/workflows/e2e-develop.yml
+++ b/.github/workflows/e2e-develop.yml
@@ -70,16 +70,20 @@ jobs:
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt/$max_attempts..."
 
-            if curl -s -f -o /dev/null --max-time 10 "$TARGET_URL"; then
-              echo "✅ Deployment is ready!"
+            # Check deployment status (HTTP 401 is acceptable for protected environments)
+            status_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$TARGET_URL" || echo "000")
+
+            if [ "$status_code" = "200" ] || [ "$status_code" = "401" ]; then
+              echo "✅ Deployment is ready! (HTTP $status_code)"
               break
             fi
 
             if [ $attempt -eq $max_attempts ]; then
-              echo "❌ Deployment not ready after $max_attempts attempts"
+              echo "❌ Deployment not ready after $max_attempts attempts (HTTP $status_code)"
               exit 1
             fi
 
+            echo "⏳ Deployment not ready yet (HTTP $status_code), waiting..."
             sleep 10
             attempt=$((attempt + 1))
           done


### PR DESCRIPTION
- Update e2e-develop.yml to accept both HTTP 200 and 401 responses
- HTTP 401 is expected for Vercel protected environments requiring OAuth
- Prevents infinite waiting loops when deployment is actually ready
- Enables E2E automation to proceed with browser-based authentication

🤖 Generated with [Claude Code](https://claude.ai/code)

## 概要

<!-- このPRの目的と変更内容を簡潔に説明してください -->

## 関連Issue

<!-- 関連するIssueがあればリンクしてください -->

- Closes #
- Related to #

## レビューポイント

<!-- 特に注意して見てほしい箇所や変更理由があれば記載してください -->

---

<!-- ⚡ この下に変更ファイル詳細とコード分析が自動で追加されます -->


🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 70a7c97 fix: handle HTTP 401 as valid deployment status in E2E workflow

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/workflows/e2e-develop.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*