### PR TITLE
fix: correct yoromeki rule priority for trump/counter jacks

### DIFF
--- a/src/lib/napoleonCardRules.ts
+++ b/src/lib/napoleonCardRules.ts
@@ -189,14 +189,19 @@ export function checkYoromekiRule(
 
   if (!mightyCard || !heartQueenCard) return null
 
-  // 切り札Jや裏Jがある場合は無効
-  const hasTrumpJack = trick.cards.some((pc) => isTrumpJack(pc.card, trumpSuit))
-  const hasCounterJack = trick.cards.some((pc) =>
+  // よろめき状況（マイティとハートのクイーンがある）の場合
+  // 表J（切り札J）が最優先、次に裏J（counter jack）、それがなければハートのクイーン
+  const trumpJackCard = trick.cards.find((pc) =>
+    isTrumpJack(pc.card, trumpSuit)
+  )
+  if (trumpJackCard) return trumpJackCard
+
+  const counterJackCard = trick.cards.find((pc) =>
     isCounterJack(pc.card, trumpSuit)
   )
+  if (counterJackCard) return counterJackCard
 
-  if (hasTrumpJack || hasCounterJack) return null
-
+  // 表J・裏Jがない場合は、ハートのクイーンが勝つ（よろめき成功）
   return heartQueenCard
 }
 

--- a/tests/lib/napoleonCardRules.test.ts
+++ b/tests/lib/napoleonCardRules.test.ts
@@ -442,7 +442,7 @@ describe('Napoleon Card Rules', () => {
         expect(winner?.playerId).toBe('p2')
       })
 
-      it('should not apply yoromeki when trump jack is present', () => {
+      it('should return trump jack when yoromeki conditions are met but trump jack is present', () => {
         const trick: Trick = {
           id: 'test-trick',
           cards: [
@@ -487,7 +487,58 @@ describe('Napoleon Card Rules', () => {
         }
 
         const winner = checkYoromekiRule(trick, SUIT_ENUM.CLUBS)
-        expect(winner).toBeNull()
+        expect(winner).not.toBeNull()
+        expect(winner?.playerId).toBe('p3') // 表J（クラブのJ）が勝つ
+      })
+
+      it('should return counter jack when yoromeki conditions are met but counter jack is present', () => {
+        const trick: Trick = {
+          id: 'test-trick',
+          cards: [
+            createPlayedCard(
+              createCard(
+                `${SUIT_ENUM.SPADES}-${CARD_RANKS.ACE}`,
+                SUIT_ENUM.SPADES,
+                CARD_RANKS.ACE
+              ),
+              'p1',
+              0
+            ),
+            createPlayedCard(
+              createCard(
+                `${SUIT_ENUM.HEARTS}-${CARD_RANKS.QUEEN}`,
+                SUIT_ENUM.HEARTS,
+                CARD_RANKS.QUEEN
+              ),
+              'p2',
+              1
+            ),
+            createPlayedCard(
+              createCard(
+                `${SUIT_ENUM.CLUBS}-${CARD_RANKS.JACK}`,
+                SUIT_ENUM.CLUBS,
+                CARD_RANKS.JACK
+              ),
+              'p3',
+              2
+            ),
+            createPlayedCard(
+              createCard(
+                `${SUIT_ENUM.HEARTS}-${CARD_RANKS.KING}`,
+                SUIT_ENUM.HEARTS,
+                CARD_RANKS.KING
+              ),
+              'p4',
+              3
+            ),
+          ],
+          completed: true,
+        }
+
+        // スペードが切り札の場合、クラブのJが裏J
+        const winner = checkYoromekiRule(trick, SUIT_ENUM.SPADES)
+        expect(winner).not.toBeNull()
+        expect(winner?.playerId).toBe('p3') // 裏J（クラブのJ）が勝つ
       })
     })
 


### PR DESCRIPTION
## 🎯 Problem

よろめきルール（マイティ vs ハートのクイーン）において、表J（切り札J）や裏J（counter jack）があるとよろめきが無効になっていました。しかし、正しいルールでは表J・裏Jがよろめきに**勝つ**べきです。

### 具体例
- 切り札：スペード
- トリック：マイティ（♠A）、ハートのクイーン（♥Q）、スペードJ（表J）
- **修正前**: よろめき無効 → 通常強度比較でマイティが勝つ
- **修正後**: 表Jがよろめきに勝つ ✅

## 🔧 Solution

よろめきルールの優先順位を正しく実装：

### 修正した優先順位
1. **表J（切り札J）** - 最強
2. **裏J（counter jack）** - 2番目
3. **ハートのクイーン** - よろめき成功（表J・裏Jがない場合のみ）

### コード変更
- `checkYoromekiRule`関数を修正
- 表J・裏Jがある場合は無効化ではなく、それらを勝者として返す
- テストケースを新ルールに合わせて更新・追加

## 🧪 Testing

- ✅ 26個のテストが全て通過
- ✅ 表J優先のテストケース追加
- ✅ 裏J優先のテストケース追加  
- ✅ 裏Jの正しい判定確認（スペード切り札→クラブJが裏J）

## 📋 Files Changed

- `src/lib/napoleonCardRules.ts` - よろめきルール修正
- `tests/lib/napoleonCardRules.test.ts` - テストケース更新・追加

## 🎮 Impact

これで、ユーザーが報告した「スペード切り札でマイティ・ハートのクイーン・スペードJのトリックでマイティが勝ってしまう」問題が解決されます。正しく表J（スペードJ）が勝つようになります。

🤖 Generated with [Claude Code](https://claude.ai/code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 58f25c5 fix: correct yoromeki rule priority for trump/counter jacks

## 📁 Files Changed

**Total files changed: 2**

- 🔧 **Source Code**: 1 files
- 🧪 **Tests**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/lib/napoleonCardRules.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/napoleonCardRules.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/yoromeki-rule-priority
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*