### PR TITLE
feat(deps): Add groups configuration for GitHub Actions in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,3 +64,8 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "ci"
+    # グループ化（全てのGitHub Actionsを1つのPRにまとめる）
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add groups configuration to bundle all GitHub Actions updates into a single PR
- Reduce PR noise from multiple individual action updates

## Problem
Currently, Dependabot creates individual PRs for each GitHub Actions update:
- PR #245: actions/upload-artifact (4 → 7)
- PR #244: actions/github-script (7 → 8)
- PR #243: actions/cache (4 → 5)
- PR #242: actions/setup-node (4 → 6)
- PR #241: pnpm/action-setup (3 → 5)

This creates too much PR noise.

## Solution
Add `groups` configuration to GitHub Actions ecosystem:
```yaml
groups:
  github-actions:
    patterns:
      - "*"
```

This will group all GitHub Actions updates into a single PR next time Dependabot runs.

## Benefits
- ✅ Fewer PRs to review (1 PR instead of 5+)
- ✅ Easier dependency management
- ✅ Consistent with npm package grouping strategy

## Test Plan
- [x] Pre-commit hooks passed
- [ ] Wait for next Dependabot run (Monday 09:00 JST)
- [ ] Verify all GitHub Actions updates are grouped in single PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 4b2548c feat(deps): Add groups configuration for GitHub Actions in dependabot.yml

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/dependabot.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*