### PR TITLE
fix(ci): Prevent duplicate CI runs for the same commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ on:
       - "LICENSE"
       - ".gitignore"
 
+# Prevent duplicate runs for the same commit
+# For PRs: use PR number to group
+# For pushes: use branch ref to group
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci-pipeline:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches: [main, develop]
     types: [opened, synchronize, reopened]
     # Skip when only docs/config files changed (e2e-tests will be skipped)
+    # Note: .github/workflows/** is NOT ignored (workflow changes must run CI)
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -14,10 +15,12 @@ on:
       - ".husky/**"
       - "scripts/**"
       - "**.json" # Includes package.json, tsconfig.json, etc.
-      - "**.yaml"
-      - "**.yml"
       - "LICENSE"
       - ".gitignore"
+      # YAML config files (but NOT .github/workflows/**)
+      - ".github/dependabot.yml"
+      - "docker-compose.yml"
+      - "*.config.yml"
 
 # Prevent duplicate runs for the same commit
 # For PRs: use PR number to group


### PR DESCRIPTION
## Summary
- Add `concurrency` group to CI workflow
- Prevent duplicate E2E test runs for the same commit
- Cancel older runs automatically

## Problem

PR #235 (develop → main) runs E2E tests **twice** for the same commit:

```
✓ CI - e2e-tests [pull_request]  ← PR synchronize event
✓ CI - e2e-tests [push]           ← push to develop event
```

**Why this happens:**
1. New commit is pushed to `develop` → **push event fires**
2. That commit is also the head of PR #235 → **pull_request (synchronize) event fires**
3. Both events trigger CI workflow → **duplicate runs**

**Impact:**
- ❌ Wastes GitHub Actions minutes (2x usage)
- ❌ Confusing PR status (two identical checks)
- ❌ Slower feedback (both must complete)

## Solution

Add `concurrency` group to automatically cancel duplicate runs:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

**How it works:**
- **For PRs**: Group by PR number (`ci-CI-235`)
  - New run cancels previous run for same PR
- **For pushes**: Group by branch ref (`ci-CI-refs/heads/develop`)
  - New push cancels previous run for same branch
- **cancel-in-progress: true**: Automatically cancel older runs

## Behavior After Fix

### Scenario 1: Commit pushed to develop (no PR)
- ✅ push event runs CI
- ✅ No duplication (no PR context)

### Scenario 2: Commit pushed to develop (has PR #235)
1. push event starts CI → run A starts
2. pull_request event starts CI → run B starts
3. **Run B cancels run A** (same group, newer)
4. ✅ Only run B completes

### Scenario 3: PR updated directly
- ✅ pull_request event runs CI
- ✅ No duplication (no push event)

## Benefits

✅ **No duplicate runs**: Only one CI run per commit
✅ **Faster feedback**: Cancel older runs immediately
✅ **Reduced cost**: Save GitHub Actions minutes (50% reduction for release PRs)
✅ **Cleaner PR status**: Single check instead of duplicate

## Test Plan

- [x] Pre-commit hooks passed
- [ ] Merge to develop
- [ ] Create new commit on develop (triggers push + PR #235 update)
- [ ] Verify only one E2E run completes
- [ ] Verify older run is automatically cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 14e04e3 fix(ci): Allow CI to run on workflow file changes
- f1b61f4 fix(ci): Prevent duplicate CI runs for the same commit

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/workflows/ci.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*