### PR TITLE
fix: Skip E2E tests on release PRs to prevent duplicate runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,8 +33,8 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     # Run E2E tests on push to main/develop or PRs to any branch
-    if: |
-      github.event_name == 'push' || github.event_name == 'pull_request'
+    # Skip E2E for release PRs since they already run on push to develop
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '🚀 Release'))
     permissions:
       contents: read
 


### PR DESCRIPTION
## 🎯 Problem

Release PR (develop → main) では E2E テストが2回実行されていました:
1. **push イベント**: develop へのマージ時
2. **pull_request イベント**: 同じコミットが main への PR のヘッドになる時

## 🔧 Solution

`e2e.yml` に Release PR をスキップする条件を追加:

```yaml
if: github.event_name == 'push' || (github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '🚀 Release'))
```

## ✅ Benefits

- Release PR では E2E テストを実行しない（develop で既にテスト済み）
- CI 時間の短縮
- `ci.yml` と同じ動作で一貫性を保つ

## 📋 Changes

- `.github/workflows/e2e.yml`: Release PR スキップ条件を追加

## 🧪 Testing

Release PR で E2E テストが実行されないことを確認します。

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- a6aecd6 fix: Skip E2E tests on release PRs to prevent duplicate runs

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/workflows/e2e.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*