### PR TITLE
fix: remove hardcoded encryption key fallback

### DIFF
--- a/.env.docker.example
+++ b/.env.docker.example
@@ -7,3 +7,6 @@ POSTGRES_PASSWORD=local-dev-password-change-me
 
 # JWT Secret (must be at least 32 characters)
 JWT_SECRET=local-dev-jwt-secret-at-least-32-characters-long
+
+# Encryption Key for session cookies (required - generate with: openssl rand -base64 32)
+ENCRYPTION_KEY=local-dev-encryption-key-change-me!

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project-id.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
+# Encryption Key (required - generate with: openssl rand -base64 32)
+ENCRYPTION_KEY=your-encryption-key-here
+
 # Environment
 NODE_ENV=development
 NEXT_PUBLIC_APP_ENV=development

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -12,8 +12,15 @@ import {
 } from 'node:crypto'
 
 // 暗号化キー（環境変数から取得、32バイト必須）
-const ENCRYPTION_KEY =
-  process.env.ENCRYPTION_KEY || 'napoleon-game-secure-key-2024-32bytes!!'
+const ENCRYPTION_KEY = (() => {
+  const key = process.env.ENCRYPTION_KEY
+  if (key) return key
+  if (process.env.NODE_ENV === 'test')
+    return 'test-only-encryption-key-32bytes!!'
+  throw new Error(
+    'ENCRYPTION_KEY environment variable is required. Generate a secure random 32-byte key.'
+  )
+})()
 
 // キーを32バイトに正規化（AES-256要件）
 const NORMALIZED_KEY = createHash('sha256').update(ENCRYPTION_KEY).digest()


### PR DESCRIPTION
## Summary
- **[CRITICAL]** 公開リポジトリでセッションCookie暗号化キーがハードコードされていた脆弱性を修正
- `ENCRYPTION_KEY`環境変数が未設定時にフォールバック値を使用していたため、攻撃者がセッションCookieを復号可能だった
- テスト環境以外では`ENCRYPTION_KEY`環境変数を必須に変更
- `.env.example`/`.env.docker.example`に`ENCRYPTION_KEY`を追加

## Test plan
- [x] 既存の暗号化テスト（`tests/utils/encryption.test.ts`）が全パス
- [ ] `ENCRYPTION_KEY`未設定でアプリ起動するとエラーになることを確認
- [ ] Vercel環境変数に`ENCRYPTION_KEY`が設定済みであることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 258f08d fix: remove hardcoded encryption key fallback (security)

## 📁 Files Changed

**Total files changed: 3**

- 🔧 **Source Code**: 1 files
- 📄 **Other**: 2 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code

- `src/utils/encryption.ts`

#### ⚙️ Configuration


#### 📄 Other Files

- `.env.docker.example`
- `.env.example`

</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout feature/security-remove-hardcoded-encryption-key
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*