### PR TITLE
fix: always set secure flag on session cookies

### DIFF
--- a/src/lib/cookies/sessionCookies.ts
+++ b/src/lib/cookies/sessionCookies.ts
@@ -25,7 +25,7 @@ const COOKIE_MAX_AGE = 86400 // 24時間（秒）
  */
 const getCookieOptions = () => ({
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
+  secure: true,
   sameSite: 'strict' as const,
   maxAge: COOKIE_MAX_AGE,
   path: '/',


### PR DESCRIPTION
## Summary
- **[MEDIUM]** セッションCookieの`secure`フラグを常に`true`に設定
- 以前は本番環境のみ`secure: true`で、開発環境ではHTTPでCookieが送信される可能性があった
- ブラウザはlocalhostでは`secure`フラグを無視するため、開発環境への影響なし

## Test plan
- [x] 型チェック・全テスト通過（pre-commitで確認済み）
- [ ] localhost開発環境でセッションCookieが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 3f05b29 fix: always set secure flag on session cookies

## 📁 Files Changed

**Total files changed: 1**

- 🔧 **Source Code**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/cookies/sessionCookies.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout feature/security-cookie-secure-flag
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*