### PR TITLE
ci: remove main branch from CI/E2E triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
     types: [opened, synchronize, reopened]
     # Skip when only docs/config files changed (e2e-tests will be skipped)
     # Note: .github/workflows/** is NOT ignored (workflow changes must run CI)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,8 +1,6 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop]
     types: [opened, synchronize, reopened]

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,9 +2,9 @@ name: E2E Tests
 
 on:
   push:
-    branches: [main, develop]
+    branches: [develop]
   pull_request:
-    branches: [main, develop]
+    branches: [develop]
     types: [opened, synchronize, reopened]
     # Skip when only docs/config files changed
     # Note: .github/workflows/** is NOT ignored (workflow changes must run E2E)


### PR DESCRIPTION
## Summary
- CI/E2Eワークフローのトリガーからmainブランチを除外
- mainへの直接push/PRは行わない運用のため不要

## Test plan
- [x] CI/E2Eがdevelop向けPRで正常に発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 5c25bd0 ci: remove redundant push trigger from CI/E2E workflows
- 4a0dac2 ci: remove main branch from CI/E2E trigger conditions

## 📁 Files Changed

**Total files changed: 2**

- ⚙️ **Configuration**: 2 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/workflows/ci.yml`
- `.github/workflows/e2e.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*