### PR TITLE
fix(deps): bump postcss to >=8.5.10 (GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "lint-staged": "^16.4.0",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.13",
     "prettier": "^3.8.1",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2"
@@ -104,7 +104,8 @@
   },
   "pnpm": {
     "overrides": {
-      "glob@>=10.2.0 <10.5.0": ">=10.5.0"
+      "glob@>=10.2.0 <10.5.0": ">=10.5.0",
+      "postcss@<8.5.10": ">=8.5.10"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   glob@>=10.2.0 <10.5.0: ">=10.5.0"
+  postcss@<8.5.10: ">=8.5.10"
 
 importers:
   .:
@@ -61,7 +62,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.4.27(postcss@8.5.8)
+        version: 10.4.27(postcss@8.5.13)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -75,8 +76,8 @@ importers:
         specifier: ^16.4.0
         version: 16.4.0
       postcss:
-        specifier: ^8.5.8
-        version: 8.5.8
+        specifier: ^8.5.13
+        version: 8.5.13
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -1285,7 +1286,7 @@ packages:
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: ">=8.5.10"
 
   babel-jest@30.3.0:
     resolution:
@@ -2198,9 +2199,9 @@ packages:
     resolution:
       { integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA== }
 
-  nanoid@3.3.11:
+  nanoid@3.3.12:
     resolution:
-      { integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w== }
+      { integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ== }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
@@ -2365,14 +2366,9 @@ packages:
     resolution:
       { integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ== }
 
-  postcss@8.4.31:
+  postcss@8.5.13:
     resolution:
-      { integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ== }
-    engines: { node: ^10 || ^12 || >=14 }
-
-  postcss@8.5.8:
-    resolution:
-      { integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg== }
+      { integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag== }
     engines: { node: ^10 || ^12 || >=14 }
 
   prettier@3.8.1:
@@ -3620,7 +3616,7 @@ snapshots:
       "@alloc/quick-lru": 5.2.0
       "@tailwindcss/node": 4.2.2
       "@tailwindcss/oxide": 4.2.2
-      postcss: 8.5.8
+      postcss: 8.5.13
       tailwindcss: 4.2.2
 
   "@testing-library/dom@10.4.1":
@@ -3851,13 +3847,13 @@ snapshots:
 
   aria-query@5.3.2: {}
 
-  autoprefixer@10.4.27(postcss@8.5.8):
+  autoprefixer@10.4.27(postcss@8.5.13):
     dependencies:
       browserslist: 4.28.2
       caniuse-lite: 1.0.30001784
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.8
+      postcss: 8.5.13
       postcss-value-parser: 4.2.0
 
   babel-jest@30.3.0(@babel/core@7.29.0):
@@ -4743,7 +4739,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -4755,7 +4751,7 @@ snapshots:
       "@swc/helpers": 0.5.15
       baseline-browser-mapping: 2.10.13
       caniuse-lite: 1.0.30001784
-      postcss: 8.4.31
+      postcss: 8.5.13
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -4858,15 +4854,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.4.31:
+  postcss@8.5.13:
     dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

- Resolves Dependabot alert #27 ([GHSA-qx2v-qp2m-jg93](https://github.com/ksleep98/napoleon-game-4players/security/dependabot/27) / CVE-2026-41305)
- Bump direct `postcss` dep from `8.5.8` → `8.5.13`
- Add `pnpm.overrides` entry for `postcss@<8.5.10` so the transitive copy pulled in by Next.js (was `8.4.31`) is also patched

## Vulnerability summary

PostCSS < 8.5.10 does not escape `</style>` sequences when stringifying CSS ASTs. If user-submitted CSS is parsed and re-stringified into an HTML `<style>` tag, the closing tag breaks out of the style context, enabling XSS.

**Practical risk for this app: low.** We do not parse user-supplied CSS — postcss is used only at build time by Tailwind / autoprefixer. Patch is taken anyway since it's trivial and silences the alert.

## Verification

- `pnpm why postcss` → all entries now `8.5.13`
- `pnpm build` ✅
- `pnpm type-check` / pre-commit checks all pass

## Test plan

- [ ] CI green on this PR
- [ ] Dependabot alert #27 auto-closes after merge
- [ ] No regression in styling on `vercel dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- a8f5ec6 fix(deps): bump postcss to >=8.5.10 to fix XSS vulnerability

## 📁 Files Changed

**Total files changed: 2**

- ⚙️ **Configuration**: 2 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `package.json`
- `pnpm-lock.yaml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*