### PR TITLE
fix(deps): pin Node.js engine to 22.x to silence Vercel warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.15.1",
   "engines": {
-    "node": ">=22.22.0",
+    "node": "22.x",
     "pnpm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
## 🎯 概要

Vercel デプロイ時に出ている警告を解消します。

```
Warning: Detected "engines": { "node": ">=22.22.0" } in your `package.json`
that will automatically upgrade when a new major Node.js Version is released.
```

`>=22.22.0` のようなオープンレンジだと、Node.js 23.x / 24.x がリリースされた瞬間にビルド環境が黙って major upgrade されてしまうため、Vercel が警告を出しています。

## 🔧 変更内容

### 主な変更

- `package.json` の `engines.node` を `">=22.22.0"` → `"22.x"` に変更
- メジャーバージョンを 22 系に固定し、minor / patch の更新は許可

### 影響範囲

- Vercel デプロイ時の警告が消える
- ローカル / CI 環境では Node 22.x を使い続ける限り影響なし
- Node 23 が出ても自動アップグレードされなくなる(意図的に上げる時は値を変更)

## 📊 テスト結果

```
✅ TypeScript type check: passed
✅ Tests: passed (test:ci)
✅ Biome lint/format: passed
✅ Pre-commit hooks: passed
```

## 🔍 動作確認

- [x] `pnpm install` 動作確認
- [x] Pre-commit hooks 通過
- [ ] CI green
- [ ] Vercel Preview で警告が消えていること

## 📝 備考

- これは **Vercel警告のみの対応**です
- 別件で報告されている検証環境の "Failed to start game" エラーとは無関係(あちらは Supabase env 変数の Preview 環境への反映漏れ + リデプロイの問題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- e0871a9 fix(deps): pin Node.js engine to 22.x to silence Vercel warning

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `package.json`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*