### PR TITLE
fix(ml): record ai_difficulty from env var instead of player name

### DIFF
--- a/src/lib/ml/dataExtractor.ts
+++ b/src/lib/ml/dataExtractor.ts
@@ -58,12 +58,13 @@ export function extractMLTrainingData(
   // トリック番号を計算（完了したトリック数）
   const trickNumber = gameState.tricks.filter((t) => t.completed).length
 
-  // AI難易度を判定（プレイヤー名から推定）
+  // AI難易度を判定（env varを参照、コードの 'normal' は DB の 'medium' に正規化）
   let aiDifficulty: 'easy' | 'medium' | 'hard' | undefined
   if (player.isAI) {
-    if (player.name.includes('Easy')) aiDifficulty = 'easy'
-    else if (player.name.includes('Medium')) aiDifficulty = 'medium'
-    else if (player.name.includes('Hard')) aiDifficulty = 'hard'
+    const level = process.env.NEXT_PUBLIC_AI_DIFFICULTY || 'normal'
+    if (level === 'easy') aiDifficulty = 'easy'
+    else if (level === 'hard') aiDifficulty = 'hard'
+    else aiDifficulty = 'medium'
   }
 
   return {


### PR DESCRIPTION
## Summary

- ML訓練データの `ai_difficulty` が常に `null` で記録されていたバグを修正
- 従来は `player.name` に `'Easy'/'Medium'/'Hard'` が含まれるかで判定していたが、実プレイヤー名は `'AI Player 1/2/3'` のため常にマッチせず常に `undefined` (= DB上 `null`) になっていた
- AI難易度の真の出所である環境変数 `NEXT_PUBLIC_AI_DIFFICULTY` を参照するように変更
- コード側の値 `'easy' | 'normal' | 'hard'` を DB CHECK 制約 `'easy' | 'medium' | 'hard'` に合わせて正規化(`normal` → `medium`)

## Background

Supabase の `ml_training_ai_stats` ビューで集計したところ、415レコード全件 `ai_difficulty = null` だったことが判明。`docs/ml/ML_IMPLEMENTATION_ROADMAP.md` Phase 3 で AI 難易度別の精度評価を行う設計のため、今後のデータ収集に向けて修正が必要。

**既存データへの影響**: 既存415レコードは引き続き `ai_difficulty = null` のまま(本修正は今後のデータに対してのみ有効)。

## Test plan

- [x] `pnpm exec tsc --noEmit` (型チェック)
- [x] pre-commit hook (Biome / TypeScript / Jest) すべてpass
- [ ] マージ後、実際にゲームを1回プレイし `ml_training_data.ai_difficulty` カラムに値が入ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 64e5423 fix(ml): record ai_difficulty from env var instead of player name

## 📁 Files Changed

**Total files changed: 1**

- 🔧 **Source Code**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/ml/dataExtractor.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/ml-ai-difficulty-recording
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*