### PR TITLE
chore(ci): add Dependabot cooldown to block too-new versions at PR creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,12 @@ updates:
       day: "monday" # 月曜日
       time: "09:00" # JST 18:00
       timezone: "Asia/Tokyo"
+    # 公開直後のパッケージを避ける (.npmrc minimumReleaseAge と同等の役割)
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      include:
+        - "*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -58,6 +64,12 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
+    # 公開直後のパッケージを避ける (python/pyproject.toml の uv exclude-newer と同等)
+    cooldown:
+      default-days: 7
+      semver-major-days: 14
+      include:
+        - "*"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Dependabot に \`cooldown\` 設定を追加し、公開から指定日数経過するまで update PR を作らないようにする。

## 多層防御の役割分担

| 層 | 機能 | カバー範囲 |
|---|---|---|
| **Dependabot cooldown** (本PR) | PR 作成段階のゲート | Dependabot 経由の更新 |
| \`.npmrc minimumReleaseAge\` | \`pnpm install\` 時のゲート | 手動 \`pnpm add\` 含む全 npm 操作 |
| \`uv exclude-newer\` (python/pyproject.toml) | \`uv lock\` 時のゲート | 手動 \`uv add\` 含む全 pip 操作 |

これまで PR 作成段階での防御がなく、CI 段階 (\`uv lock\` 失敗) で初めて検知 → PR を都度 close する運用になっていた。本PRで PR 自体が作られないようにする。

## 設定値

- \`default-days: 7\` (基本 7 日)
- \`semver-major-days: 14\` (major bump はより慎重に)

## 背景

PR #303, #304, #316, #317 が cooldown 違反 (uv lock 失敗) で連続して作られていた。本設定でこの繰り返しを断つ。**本PR マージ後、現在 open している #316, #317 を close** 予定 (Dependabot は cooldown 経過後に再生成する)。

## 関連ドキュメント

- [Dependabot cooldown 公式ドキュメント](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown)
- docs/security/SUPPLY_CHAIN_SECURITY.md (本リポジトリの多層防御戦略)

## Test plan

- [x] dependabot.yml の YAML 構文確認 (git diff)
- [ ] マージ後、次の月曜 (Dependabot scheduled run) で PR 作成挙動を確認
- [ ] open している #316, #317 を close

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 7b9ae91 chore(ci): add Dependabot cooldown to block too-new versions at PR creation

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/dependabot.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*