### PR TITLE
chore(python): clean up imports and narrow supabase JSON type

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -17,6 +17,7 @@ import gradio as gr
 import joblib
 import numpy as np
 import pandas as pd
+import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
@@ -249,8 +250,6 @@ app = gr.mount_gradio_app(app, ui, path="/")
 
 
 if __name__ == "__main__":
-    import uvicorn
-
     logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
     # Hugging Face Spaces expects 7860; bind 0.0.0.0 for container access.
     uvicorn.run(app, host="0.0.0.0", port=7860)

--- a/python/data/fetch_data.py
+++ b/python/data/fetch_data.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
+from typing import cast
 
 import pandas as pd
 from dotenv import load_dotenv
@@ -48,7 +49,9 @@ def fetch_training_data(
             query = query.not_.is_("game_result", "null")
         query = query.order("created_at").range(offset, offset + page_size - 1)
         resp = query.execute()
-        batch = resp.data or []
+        # supabase typing for resp.data is List[JSON] (union of dict/list/scalar);
+        # every row of ml_training_data is a dict, so narrow for downstream use.
+        batch = cast(list[dict], resp.data or [])
         rows.extend(batch)
         if len(batch) < page_size:
             break


### PR DESCRIPTION
## Summary

軽微な Python リファクタリング 2 件。

### app.py
\`import uvicorn\` を \`if __name__ == \"__main__\"\` ブロックから module 先頭の import グループに移動 (PEP 8 順序)。

### data/fetch_data.py
supabase の \`resp.data\` は \`List[JSON]\` (dict/list/scalar の union) で typed されており、\`rows: list[dict]\` への \`extend\` が pyright で型不一致エラーを出していた。\`ml_training_data\` の各行は確実に dict なので \`typing.cast\` で narrow。

\`\`\`
Argument of type \"List[JSON]\" cannot be assigned to parameter
\"iterable\" of type \"Iterable[dict[Unknown, Unknown]]\"
\`\`\`

## Test plan

- [x] \`ruff check .\` pass
- [x] \`black --check .\` pass
- [x] \`pyright app.py data/ model/\` 0 errors
- [x] pre-commit hook (Biome / TypeScript / Jest) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- adeabfa chore(python): clean up imports and narrow supabase JSON type

## 📁 Files Changed

**Total files changed: 2**

- 📄 **Other**: 2 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files

- `python/app.py`
- `python/data/fetch_data.py`

</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*