### PR TITLE
feat(ml): add mlClient for HF Spaces inference API (Phase 4.1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ NEXT_PUBLIC_APP_ENV=development
 # AI Difficulty (easy, normal, hard)
 NEXT_PUBLIC_AI_DIFFICULTY=normal
 
+# ML Inference API (Hugging Face Spaces - napoleon-ml-trainer)
+# 空文字または未設定の場合、ML 推論はスキップして既存の MCTS にフォールバックします。
+# 例: NEXT_PUBLIC_ML_API_URL=https://ksleep98-napoleon-ml-trainer.hf.space
+NEXT_PUBLIC_ML_API_URL=
+
 # Optional: Database URL (for direct connections)
 # DATABASE_URL=postgresql://postgres:[PASSWORD]@db.xxxxx.supabase.co:5432/postgres
 

--- a/src/lib/ml/mlClient.ts
+++ b/src/lib/ml/mlClient.ts
@@ -1,0 +1,111 @@
+import type { Card, Suit } from '@/types/game'
+
+export type Role = 'napoleon' | 'adjutant' | 'allied'
+
+export interface PredictCardRequest {
+  hand: Card[]
+  tableCards: Card[]
+  currentSuit: Suit | null
+  trumpSuit: Suit | null
+  role: Role
+  isNapoleonTeam: boolean
+  trickNumber: number
+}
+
+export interface PredictCardCandidate {
+  cardId: string // "${suit}-${rank}" e.g. "hearts-A"
+  confidence: number
+}
+
+export interface PredictCardResponse {
+  predictedCardId: string
+  confidence: number
+  topK: PredictCardCandidate[]
+}
+
+// HF Space free tier sleeps after 5min idle and cold-starts in ~10-15s.
+// Keep timeout generous enough to cover cold start, but bounded so the AI
+// turn does not stall the UI indefinitely.
+const DEFAULT_TIMEOUT_MS = 20_000
+
+/**
+ * Call the napoleon-ml-trainer inference API.
+ *
+ * Returns null when:
+ * - NEXT_PUBLIC_ML_API_URL is not configured
+ * - Network/timeout/server error
+ * - Model not trained yet (503)
+ *
+ * Callers should fall back to the local MCTS strategy on null.
+ */
+export async function predictBestCard(
+  request: PredictCardRequest,
+  options: { timeoutMs?: number; signal?: AbortSignal } = {}
+): Promise<PredictCardResponse | null> {
+  const baseUrl = process.env.NEXT_PUBLIC_ML_API_URL
+  if (!baseUrl) {
+    return null
+  }
+
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(),
+    options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  )
+  if (options.signal) {
+    options.signal.addEventListener('abort', () => controller.abort(), {
+      once: true,
+    })
+  }
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\/+$/, '')}/api/predict-card`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          hand: request.hand,
+          table_cards: request.tableCards,
+          current_suit: request.currentSuit,
+          trump_suit: request.trumpSuit,
+          role: request.role,
+          is_napoleon_team: request.isNapoleonTeam,
+          trick_number: request.trickNumber,
+        }),
+        signal: controller.signal,
+      }
+    )
+
+    if (!response.ok) {
+      // 503 = model not yet trained on the Space; treat as a soft miss.
+      if (response.status !== 503) {
+        console.warn('[mlClient] predict-card HTTP error', response.status)
+      }
+      return null
+    }
+
+    const data = (await response.json()) as {
+      predicted_card_id: string
+      confidence: number
+      top_k: { card_id: string; confidence: number }[]
+    }
+    return {
+      predictedCardId: data.predicted_card_id,
+      confidence: data.confidence,
+      topK: data.top_k.map((c) => ({
+        cardId: c.card_id,
+        confidence: c.confidence,
+      })),
+    }
+  } catch (error) {
+    if ((error as Error)?.name === 'AbortError') {
+      console.warn('[mlClient] predict-card timed out')
+    } else {
+      console.warn('[mlClient] predict-card failed:', (error as Error)?.message)
+    }
+    return null
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/tests/lib/ml/mlClient.test.ts
+++ b/tests/lib/ml/mlClient.test.ts
@@ -1,0 +1,176 @@
+import { predictBestCard } from '@/lib/ml/mlClient'
+import type { Card } from '@/types/game'
+
+const sampleHand: Card[] = [
+  { id: 'hearts-A', suit: 'hearts', rank: 'A', value: 14 },
+  { id: 'spades-K', suit: 'spades', rank: 'K', value: 13 },
+]
+
+const baseRequest = {
+  hand: sampleHand,
+  tableCards: [],
+  currentSuit: null,
+  trumpSuit: null,
+  role: 'allied' as const,
+  isNapoleonTeam: false,
+  trickNumber: 0,
+}
+
+describe('predictBestCard', () => {
+  const originalUrl = process.env.NEXT_PUBLIC_ML_API_URL
+  const originalFetch = global.fetch
+  const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_ML_API_URL = originalUrl
+    global.fetch = originalFetch
+    warnSpy.mockClear()
+  })
+
+  afterAll(() => {
+    warnSpy.mockRestore()
+  })
+
+  it('returns null and does not fetch when NEXT_PUBLIC_ML_API_URL is unset', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = ''
+    const fetchMock = jest.fn()
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    const result = await predictBestCard(baseRequest)
+
+    expect(result).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('returns parsed response on 200', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = 'https://ml.example/'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        predicted_card_id: 'hearts-A',
+        confidence: 0.42,
+        top_k: [
+          { card_id: 'hearts-A', confidence: 0.42 },
+          { card_id: 'spades-K', confidence: 0.11 },
+        ],
+      }),
+    }) as unknown as typeof fetch
+
+    const result = await predictBestCard(baseRequest)
+
+    expect(result).toEqual({
+      predictedCardId: 'hearts-A',
+      confidence: 0.42,
+      topK: [
+        { cardId: 'hearts-A', confidence: 0.42 },
+        { cardId: 'spades-K', confidence: 0.11 },
+      ],
+    })
+  })
+
+  it('posts snake_case payload to /api/predict-card and strips trailing slash from base URL', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = 'https://ml.example///'
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        predicted_card_id: 'hearts-A',
+        confidence: 1,
+        top_k: [],
+      }),
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    await predictBestCard({
+      ...baseRequest,
+      currentSuit: 'hearts',
+      trumpSuit: 'spades',
+      role: 'napoleon',
+      isNapoleonTeam: true,
+      trickNumber: 3,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://ml.example/api/predict-card',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body)
+    expect(body).toEqual({
+      hand: sampleHand,
+      table_cards: [],
+      current_suit: 'hearts',
+      trump_suit: 'spades',
+      role: 'napoleon',
+      is_napoleon_team: true,
+      trick_number: 3,
+    })
+  })
+
+  it('returns null on 503 (model not yet trained) without warning', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = 'https://ml.example'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    }) as unknown as typeof fetch
+
+    const result = await predictBestCard(baseRequest)
+
+    expect(result).toBeNull()
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns null and warns on other HTTP errors', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = 'https://ml.example'
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    }) as unknown as typeof fetch
+
+    const result = await predictBestCard(baseRequest)
+
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP error'),
+      500
+    )
+  })
+
+  it('returns null on network error', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = 'https://ml.example'
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new Error('network down')) as unknown as typeof fetch
+
+    const result = await predictBestCard(baseRequest)
+
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('failed'),
+      'network down'
+    )
+  })
+
+  it('returns null on timeout (AbortError)', async () => {
+    process.env.NEXT_PUBLIC_ML_API_URL = 'https://ml.example'
+    global.fetch = jest.fn().mockImplementation((_, init: RequestInit) => {
+      return new Promise((_, reject) => {
+        init.signal?.addEventListener('abort', () => {
+          const err = new Error('aborted')
+          err.name = 'AbortError'
+          reject(err)
+        })
+      })
+    }) as unknown as typeof fetch
+
+    const result = await predictBestCard(baseRequest, { timeoutMs: 10 })
+
+    expect(result).toBeNull()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('timed out'))
+  })
+})


### PR DESCRIPTION
## Summary

[ML_IMPLEMENTATION_ROADMAP](./docs/ml/ML_IMPLEMENTATION_ROADMAP.md) Phase 4 の前半。Hugging Face Spaces (`napoleon-ml-trainer`) の推論 API を叩く client を追加。**AI 戦略への統合 (Phase 4.2) は別 PR** で行うため、本 PR では既存のゲーム挙動に影響しません。

## What this PR adds

| ファイル | 役割 |
|---|---|
| \`src/lib/ml/mlClient.ts\` | \`predictBestCard()\` — HF Space に POST /api/predict-card する関数 |
| \`tests/lib/ml/mlClient.test.ts\` | Jest テスト 7 件(URL未設定 / 200 / 503 / 5xx / network error / timeout / payload 変換) |
| \`.env.example\` | \`NEXT_PUBLIC_ML_API_URL\` 追加 (空文字 = 機能無効) |

## Design

- **失敗時は null を返す**(throw しない) → 呼び出し側はシンプルに \`null\` チェック後に既存 MCTS フォールバック可
- **タイムアウト 20 秒**(HF Space free tier の cold start ~10-15s を考慮)
- **503 は警告なし**(モデル未訓練時の正常状態のため)、それ以外の HTTP エラーは \`console.warn\`
- **camelCase ⇄ snake_case 変換**: TypeScript 慣習で受け取り、Python API に snake_case で送る
- \`NEXT_PUBLIC_ML_API_URL\` が未設定なら **fetch すら呼ばない**(ローカル/CI で気にせず無効化できる)

## HF Space 状況

- URL: https://ksleep98-napoleon-ml-trainer.hf.space
- Stage: RUNNING ✅
- \`/api/health\` 200 OK 確認済
- ただし**まだモデル未訓練** (\`model.status = no_model\`) → 現状の API 呼び出しは 503 を返す
- Phase 4.2 で実際に AI 戦略から呼ぶ時は MCTS フォールバックで実害なし

## Test plan

- [x] \`pnpm tsc --noEmit\` pass
- [x] \`pnpm jest tests/lib/ml/mlClient.test.ts\` → 7/7 pass
- [x] \`pnpm biome check src/lib/ml/ tests/lib/ml/\` pass
- [x] pre-commit hook (Biome / TS / Jest) pass

## Not in scope (別 PR)

- Phase 4.2: \`aiStrategy.ts\` で MCTS と ML の切り替え実装
- Vercel env vars (\`NEXT_PUBLIC_ML_API_URL\`) の設定 — マージ後にユーザー作業

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 6d019ae feat(ml): add mlClient for HF Spaces inference API (Phase 4.1)

## 📁 Files Changed

**Total files changed: 3**

- 🔧 **Source Code**: 1 files
- 🧪 **Tests**: 1 files
- 📄 **Other**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/lib/ml/mlClient.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/ml/mlClient.ts`

#### ⚙️ Configuration


#### 📄 Other Files

- `.env.example`

</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout feature/ml-client-phase4-1
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*