### PR TITLE
feat(ml): integrate ML inference into AI card selection (Phase 4.2)

### DIFF
--- a/src/lib/ai/aiStrategy.ts
+++ b/src/lib/ai/aiStrategy.ts
@@ -3,6 +3,7 @@
  * ヒューリスティック、MCTS、ハイブリッドの選択
  */
 
+import { predictBestCard, type Role } from '@/lib/ml/mlClient'
 import type { Card, GameState, Player } from '@/types/game'
 import { getPlayableCards } from './gameSimulator'
 import {
@@ -11,6 +12,12 @@ import {
   selectCardWithDeterminization,
 } from './monteCarloAI'
 import { selectBestStrategicCard } from './strategicCardEvaluator'
+
+/**
+ * ML 推論の採用基準。閾値未満は MCTS / heuristic にフォールバックする。
+ * 値の根拠: docs/ml/ML_IMPLEMENTATION_ROADMAP.md Phase 4.2 (信頼度 0.6 以上)
+ */
+const ML_CONFIDENCE_THRESHOLD = 0.6
 
 /**
  * AI戦略タイプ
@@ -159,6 +166,68 @@ function calculateGameProgress(gameState: GameState): number {
   const totalTricks = 12
   const completedTricks = gameState.tricks.length
   return completedTricks / totalTricks
+}
+
+/**
+ * ML 推論を優先するラッパー。信頼度が閾値以上かつ手札のカードを返してきた場合のみ
+ * その手を採用し、そうでなければ既存の selectAICard にフォールバックする。
+ *
+ * NEXT_PUBLIC_ML_API_URL 未設定時は ML を呼ばず、即フォールバックするので
+ * ローカル開発や ML 無効化環境でも追加コストはない。
+ */
+export async function selectAICardWithML(
+  gameState: GameState,
+  player: Player,
+  config: AIStrategyConfig
+): Promise<Card | null> {
+  const playableCards = getPlayableCards(gameState, player.id)
+  if (playableCards.length === 0) return null
+  if (playableCards.length === 1) return playableCards[0]
+
+  const mlPick = await tryMLPick(gameState, player, playableCards)
+  if (mlPick) return mlPick
+
+  return selectAICard(gameState, player, config)
+}
+
+async function tryMLPick(
+  gameState: GameState,
+  player: Player,
+  playableCards: Card[]
+): Promise<Card | null> {
+  const role: Role = player.isNapoleon
+    ? 'napoleon'
+    : player.isAdjutant
+      ? 'adjutant'
+      : 'allied'
+
+  const prediction = await predictBestCard({
+    hand: player.hand,
+    tableCards: gameState.currentTrick.cards.map((pc) => pc.card),
+    currentSuit: gameState.leadingSuit ?? null,
+    trumpSuit: gameState.trumpSuit ?? null,
+    role,
+    isNapoleonTeam: player.isNapoleon || player.isAdjutant,
+    trickNumber: gameState.tricks.filter((t) => t.completed).length,
+  })
+
+  if (!prediction) return null
+  if (prediction.confidence < ML_CONFIDENCE_THRESHOLD) return null
+
+  const playableById = new Map(playableCards.map((c) => [c.id, c]))
+
+  // 第一候補を採用 (playable で閾値以上)
+  const primary = playableById.get(prediction.predictedCardId)
+  if (primary) return primary
+
+  // 第一候補が手札外/フォロー違反の場合は top-k から playable で閾値以上を探す
+  for (const candidate of prediction.topK) {
+    if (candidate.confidence < ML_CONFIDENCE_THRESHOLD) break
+    const match = playableById.get(candidate.cardId)
+    if (match) return match
+  }
+
+  return null
 }
 
 /**

--- a/src/lib/ai/gameTricks.ts
+++ b/src/lib/ai/gameTricks.ts
@@ -18,7 +18,7 @@ import {
 import {
   type AIDifficultyLevel,
   getStrategyConfigByDifficulty,
-  selectAICard as selectAICardWithStrategy,
+  selectAICardWithML,
 } from './aiStrategy'
 import { allianceAIStrategy } from './alliance'
 import { getPlayableCards as getPlayableCardsFromSimulator } from './gameSimulator'
@@ -263,10 +263,10 @@ async function selectAICard(
   const difficultyLevel: AIDifficultyLevel =
     (process.env.NEXT_PUBLIC_AI_DIFFICULTY as AIDifficultyLevel) || 'normal'
 
-  // ハイブリッド戦略を使用
+  // ML 推論 → 信頼度不足やエラー時はハイブリッド戦略にフォールバック
   try {
     const strategyConfig = getStrategyConfigByDifficulty(difficultyLevel)
-    const selectedCard = selectAICardWithStrategy(
+    const selectedCard = await selectAICardWithML(
       gameState,
       currentPlayer,
       strategyConfig

--- a/tests/lib/ai/selectAICardWithML.test.ts
+++ b/tests/lib/ai/selectAICardWithML.test.ts
@@ -1,0 +1,205 @@
+import { selectAICardWithML } from '@/lib/ai/aiStrategy'
+import { GAME_PHASES } from '@/lib/constants'
+import { predictBestCard } from '@/lib/ml/mlClient'
+import type { Card, GameState, Player, Trick } from '@/types/game'
+
+jest.mock('@/lib/ml/mlClient', () => ({
+  predictBestCard: jest.fn(),
+}))
+
+const predictMock = predictBestCard as jest.MockedFunction<
+  typeof predictBestCard
+>
+
+const card = (suit: Card['suit'], rank: Card['rank'], value: number): Card => ({
+  id: `${suit}-${rank}`,
+  suit,
+  rank,
+  value,
+})
+
+const hand: Card[] = [
+  card('hearts', 'A', 14),
+  card('hearts', 'K', 13),
+  card('spades', '7', 7),
+]
+
+const napoleonPlayer: Player = {
+  id: 'p1',
+  name: 'P1',
+  hand,
+  isNapoleon: true,
+  isAdjutant: false,
+  position: 1,
+  isAI: true,
+}
+
+const otherPlayer: Player = {
+  id: 'p2',
+  name: 'P2',
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  position: 2,
+  isAI: true,
+}
+
+const emptyTrick: Trick = { id: 't', cards: [], completed: false }
+
+const baseState: GameState = {
+  id: 'g',
+  players: [napoleonPlayer, otherPlayer, otherPlayer, otherPlayer],
+  currentTrick: emptyTrick,
+  tricks: [],
+  currentPlayerIndex: 0,
+  phase: GAME_PHASES.PLAYING,
+  leadingSuit: undefined,
+  trumpSuit: 'hearts',
+  hiddenCards: [],
+  passedPlayers: [],
+  declarationTurn: 0,
+  needsRedeal: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+}
+
+const config = {
+  strategy: 'heuristic' as const,
+  difficulty: 'normal' as const,
+}
+
+describe('selectAICardWithML', () => {
+  afterEach(() => {
+    predictMock.mockReset()
+  })
+
+  it('returns the only playable card without calling ML', async () => {
+    const single = [card('hearts', 'A', 14)]
+    const state = {
+      ...baseState,
+      players: [
+        { ...napoleonPlayer, hand: single },
+        otherPlayer,
+        otherPlayer,
+        otherPlayer,
+      ],
+    }
+    const result = await selectAICardWithML(state, state.players[0], config)
+    expect(result?.id).toBe('hearts-A')
+    expect(predictMock).not.toHaveBeenCalled()
+  })
+
+  it('uses ML pick when confidence >= threshold and card is in playable set', async () => {
+    predictMock.mockResolvedValue({
+      predictedCardId: 'hearts-K',
+      confidence: 0.75,
+      topK: [{ cardId: 'hearts-K', confidence: 0.75 }],
+    })
+
+    const result = await selectAICardWithML(baseState, napoleonPlayer, config)
+    expect(result?.id).toBe('hearts-K')
+    expect(predictMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to local strategy when ML confidence is below threshold', async () => {
+    predictMock.mockResolvedValue({
+      predictedCardId: 'hearts-K',
+      confidence: 0.4,
+      topK: [{ cardId: 'hearts-K', confidence: 0.4 }],
+    })
+
+    const result = await selectAICardWithML(baseState, napoleonPlayer, config)
+    // Fallback picked something; just ensure it is from the hand (not the ML pick rejected)
+    expect(result).not.toBeNull()
+    expect(hand.map((c) => c.id)).toContain(result?.id)
+  })
+
+  it('skips ML when predictBestCard returns null (e.g., URL unset, server down)', async () => {
+    predictMock.mockResolvedValue(null)
+    const result = await selectAICardWithML(baseState, napoleonPlayer, config)
+    expect(result).not.toBeNull()
+    expect(predictMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects ML pick when predicted card is not in playable cards', async () => {
+    // Follow-suit: leading hearts → only hearts-* are playable
+    const state: GameState = {
+      ...baseState,
+      currentTrick: {
+        id: 't',
+        cards: [{ card: card('hearts', '5', 5), playerId: 'pX', order: 0 }],
+        leadingSuit: 'hearts',
+        completed: false,
+      },
+      leadingSuit: 'hearts',
+    }
+
+    predictMock.mockResolvedValue({
+      predictedCardId: 'spades-7', // not playable (must follow hearts)
+      confidence: 0.9,
+      topK: [
+        { cardId: 'spades-7', confidence: 0.9 },
+        { cardId: 'hearts-A', confidence: 0.7 }, // fallback candidate
+      ],
+    })
+
+    const result = await selectAICardWithML(state, napoleonPlayer, config)
+    expect(result?.id).toBe('hearts-A') // top-K fallback that is playable
+  })
+
+  it('falls back to local strategy when no top-K candidate is both playable and above threshold', async () => {
+    const state: GameState = {
+      ...baseState,
+      currentTrick: {
+        id: 't',
+        cards: [{ card: card('hearts', '5', 5), playerId: 'pX', order: 0 }],
+        leadingSuit: 'hearts',
+        completed: false,
+      },
+      leadingSuit: 'hearts',
+    }
+    predictMock.mockResolvedValue({
+      predictedCardId: 'spades-7',
+      confidence: 0.9,
+      topK: [
+        { cardId: 'spades-7', confidence: 0.9 },
+        { cardId: 'clubs-2', confidence: 0.7 }, // not in hand
+        { cardId: 'hearts-A', confidence: 0.3 }, // below threshold
+      ],
+    })
+    const result = await selectAICardWithML(state, napoleonPlayer, config)
+    // Falls back; should still pick a hearts card (follow-suit)
+    expect(result?.suit).toBe('hearts')
+  })
+
+  it('sends correct role and trick_number to the ML API', async () => {
+    // Return a high-confidence pick so we do not hit the heuristic fallback,
+    // which requires extra game state this test does not set up.
+    predictMock.mockResolvedValue({
+      predictedCardId: 'hearts-A',
+      confidence: 0.95,
+      topK: [{ cardId: 'hearts-A', confidence: 0.95 }],
+    })
+    const state: GameState = {
+      ...baseState,
+      tricks: [
+        { ...emptyTrick, id: 't1', completed: true },
+        { ...emptyTrick, id: 't2', completed: true },
+      ],
+    }
+    const adjutant: Player = {
+      ...napoleonPlayer,
+      isNapoleon: false,
+      isAdjutant: true,
+    }
+    await selectAICardWithML(state, adjutant, config)
+    expect(predictMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'adjutant',
+        isNapoleonTeam: true,
+        trickNumber: 2,
+        trumpSuit: 'hearts',
+      })
+    )
+  })
+})


### PR DESCRIPTION
## Summary

[ML_IMPLEMENTATION_ROADMAP](./docs/ml/ML_IMPLEMENTATION_ROADMAP.md) Phase 4 後半。Phase 4.1 (#330) で追加した \`mlClient.predictBestCard\` を AI のカード選択フローに統合。**ML 推論を試して、ダメなら既存戦略にフォールバック** という安全構成です。

## Changes

### \`src/lib/ai/aiStrategy.ts\`
- 新規 \`selectAICardWithML(gameState, player, config): Promise<Card | null>\` を export
- 内部 helper \`tryMLPick\` で推論結果を **検証** してから採用:
  1. 信頼度 >= \`ML_CONFIDENCE_THRESHOLD\` (0.6)
  2. 予測カードが手札の playable cards に含まれる
  3. 第一候補が条件を満たさない場合は **top-k から playable & 閾値以上** を順に試す
  4. すべて満たさなければ既存 \`selectAICard\` (hybrid/MCTS) にフォールバック

### \`src/lib/ai/gameTricks.ts\`
- 既存の \`selectAICardWithStrategy\` (sync) 呼び出しを \`await selectAICardWithML\` に差し替え
- 呼び出し側はもともと async / try-catch あり → **変更最小**

### \`tests/lib/ai/selectAICardWithML.test.ts\` (新規 7件)
| # | テスト |
|---|---|
| 1 | 唯一の playable は ML 呼ばずに即返す |
| 2 | 信頼度 >= 閾値 & 手札内 → ML pick 採用 |
| 3 | 信頼度 < 閾値 → フォールバック |
| 4 | mlClient が null → フォールバック |
| 5 | 第一候補が playable でない → top-k から playable & 閾値以上を採用 |
| 6 | top-k 全て不適格 → フォールバック |
| 7 | role / trick_number / trumpSuit が正しく API に渡る |

## 安全性

| シナリオ | 挙動 |
|---|---|
| \`NEXT_PUBLIC_ML_API_URL\` 未設定 | mlClient が即 null → 追加コストゼロでフォールバック |
| HF Space 未訓練 (現状) | 503 → null → フォールバック (実害なし) |
| HF Space cold start 中 | 20s タイムアウト後 null → フォールバック |
| ML が手札外のカードを推薦 | playable 検証で弾く |
| 信頼度低い | 閾値 0.6 で足切り |

つまり、**現状の本番でマージしても AI の挙動は変わらない** (常にフォールバック発火)。モデル訓練後に Vercel env で \`NEXT_PUBLIC_ML_API_URL\` を設定すれば ML が効き始める。

## Test plan

- [x] \`pnpm tsc --noEmit\` → 0 errors
- [x] \`pnpm test:ci\` → 43 suites / 658 tests pass
- [x] \`pnpm biome check\` → 既存 warnings 2件のみ (本PR外)
- [x] pre-commit hook pass

## Follow-up (別タスク)

- Vercel env vars: \`NEXT_PUBLIC_ML_API_URL=https://ksleep98-napoleon-ml-trainer.hf.space\` を Development/Preview/Production に追加 (ユーザー作業)
- HF Space でモデル訓練 (Gradio UI の Train ボタン or local train + commit)
- Phase 5: モデル評価 / データ拡充 / ハイパラチューニング

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- defda5f feat(ml): integrate ML inference into AI card selection (Phase 4.2)

## 📁 Files Changed

**Total files changed: 3**

- 🔧 **Source Code**: 2 files
- 🧪 **Tests**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/lib/ai/selectAICardWithML.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/ai/aiStrategy.ts`
- `src/lib/ai/gameTricks.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout feature/ml-ai-integration-phase4-2
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*