### PR TITLE
chore(ml): lower ML_CONFIDENCE_THRESHOLD from 0.6 to 0.5

### DIFF
--- a/src/lib/ai/aiStrategy.ts
+++ b/src/lib/ai/aiStrategy.ts
@@ -15,9 +15,14 @@ import { selectBestStrategicCard } from './strategicCardEvaluator'
 
 /**
  * ML 推論の採用基準。閾値未満は MCTS / heuristic にフォールバックする。
- * 値の根拠: docs/ml/ML_IMPLEMENTATION_ROADMAP.md Phase 4.2 (信頼度 0.6 以上)
+ *
+ * ロードマップ (docs/ml/ML_IMPLEMENTATION_ROADMAP.md Phase 4.2) の初期値は 0.6。
+ * ただし accuracy ~22%・データ ~420 ゲーム時点で top-1 confidence は最大
+ * 0.58 程度に留まり、0.6 では実質採用ゼロだった。実プレイで ML が「ほぼ確信
+ * している」ケースを採用させて挙動を観察するため、当面 0.5 に下げる。
+ * データ蓄積で confidence が全体的に上がってきたら 0.6 に戻す予定。
  */
-const ML_CONFIDENCE_THRESHOLD = 0.6
+const ML_CONFIDENCE_THRESHOLD = 0.5
 
 type MLLogEvent = 'adopt' | 'adopt-topk' | 'fallback' | 'skip'
 


### PR DESCRIPTION
## Summary

実プレイで ML 推論が一切採用されない問題を解消する暫定対応。

ロードマップ (Phase 4.2) の初期値 0.6 では、accuracy 22% / データ ~420 ゲーム時点の confidence 分布 (max 0.584) では **0 件採用** だった。0.5 に下げて「ほぼ確信レベル」の予測を採用させ、ML が実際に動く様子を観察可能にする。

## Diff

\`\`\`diff
-const ML_CONFIDENCE_THRESHOLD = 0.6
+const ML_CONFIDENCE_THRESHOLD = 0.5
\`\`\`

(コメントも合わせて更新)

## 直近1ゲームの予測 confidence 分布

\`\`\`
0.584  diamonds-K   ← 旧 0.6 では fallback、新 0.5 で adopt
0.352  spades-A     ← 引き続き fallback
0.311  hearts-Q     ← 引き続き fallback
0.305  hearts-Q     ← 引き続き fallback
0.220 〜            ← 引き続き fallback
\`\`\`

→ 1 ゲーム 33 ML 判断のうち **1件が adopt に変わる**(3%)。少なめだが「ML が選んだ瞬間」が観察できる。

## tradeoff

| 観点 | 評価 |
|---|---|
| ML 採用率 | 0% → ~3-5% |
| 採用される予測の質 | 0.5 以上 = 「ほぼ確信」レベル、信頼度は妥当 |
| AI が弱くなるリスク | 限定的(0.5以上は本当に確信ある予測) |
| 戻し方 | データ蓄積で confidence 全体上昇したらコード変更で 0.6 に戻す予定(コメントに方針記載) |

## Test plan

- [x] 既存7件のテスト全部 pass(挙動変更なし)
  - 0.75 → adopt(両閾値で動作)
  - 0.4 → fallback(両閾値で動作)
  - top-k 0.7 → adopt-topk(両閾値で動作)
  - top-k 0.3 → fallback(両閾値で動作)
  - 0.95 → adopt(両閾値で動作)
- [x] \`pnpm tsc --noEmit\` pass
- [x] pre-commit hook pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 0e96085 chore(ml): lower ML_CONFIDENCE_THRESHOLD from 0.6 to 0.5

## 📁 Files Changed

**Total files changed: 1**

- 🔧 **Source Code**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/ai/aiStrategy.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout chore/ml-threshold-0.5
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*