### PR TITLE
chore(ml): lower ML_CONFIDENCE_THRESHOLD from 0.5 to 0.2

### DIFF
--- a/src/lib/ai/aiStrategy.ts
+++ b/src/lib/ai/aiStrategy.ts
@@ -17,12 +17,19 @@ import { selectBestStrategicCard } from './strategicCardEvaluator'
  * ML 推論の採用基準。閾値未満は MCTS / heuristic にフォールバックする。
  *
  * ロードマップ (docs/ml/ML_IMPLEMENTATION_ROADMAP.md Phase 4.2) の初期値は 0.6。
- * ただし accuracy ~22%・データ ~420 ゲーム時点で top-1 confidence は最大
- * 0.58 程度に留まり、0.6 では実質採用ゼロだった。実プレイで ML が「ほぼ確信
- * している」ケースを採用させて挙動を観察するため、当面 0.5 に下げる。
- * データ蓄積で confidence が全体的に上がってきたら 0.6 に戻す予定。
+ * しかし 526 ゲーム/accuracy 26%・top-3 52% の時点でも、実プレイの top-1
+ * confidence は概ね 0.10〜0.25 に分布し、ゲームによって max が 0.24〜0.58
+ * と大きく振れる。これは Random Forest を 52 クラス分類で使う構造上の制約
+ * (200本の木の票が複数候補に分散) であり、データ追加では緩やかにしか
+ * 改善しない。
+ *
+ * 一方 top-3 accuracy は 52% に達しており、信頼度が低めでも「正解に近い
+ * 手」が選ばれている可能性は高い。実プレイで ML を実際に発火させて挙動
+ * を観察するため、当面 0.2 まで下げる(全 ML 判断のうち 20-40% が採用
+ * される想定)。データ拡充・キャリブレーション・別モデル等で confidence
+ * 分布が改善したら段階的に 0.3 → 0.5 → 0.6 に戻す。
  */
-const ML_CONFIDENCE_THRESHOLD = 0.5
+const ML_CONFIDENCE_THRESHOLD = 0.2
 
 type MLLogEvent = 'adopt' | 'adopt-topk' | 'fallback' | 'skip'
 

--- a/tests/lib/ai/selectAICardWithML.test.ts
+++ b/tests/lib/ai/selectAICardWithML.test.ts
@@ -104,8 +104,8 @@ describe('selectAICardWithML', () => {
   it('falls back to local strategy when ML confidence is below threshold', async () => {
     predictMock.mockResolvedValue({
       predictedCardId: 'hearts-K',
-      confidence: 0.4,
-      topK: [{ cardId: 'hearts-K', confidence: 0.4 }],
+      confidence: 0.15,
+      topK: [{ cardId: 'hearts-K', confidence: 0.15 }],
     })
 
     const result = await selectAICardWithML(baseState, napoleonPlayer, config)
@@ -164,7 +164,7 @@ describe('selectAICardWithML', () => {
       topK: [
         { cardId: 'spades-7', confidence: 0.9 },
         { cardId: 'clubs-2', confidence: 0.7 }, // not in hand
-        { cardId: 'hearts-A', confidence: 0.3 }, // below threshold
+        { cardId: 'hearts-A', confidence: 0.1 }, // below threshold
       ],
     })
     const result = await selectAICardWithML(state, napoleonPlayer, config)


### PR DESCRIPTION
## Summary

実プレイで ML 推論が依然として一切採用されない問題を解消する2段階目の暫定対応。閾値 \`0.5 → 0.2\`。

## 背景

526 ゲーム / accuracy 26% / top-3 52% まで蓄積した時点でも、実プレイの top-1 confidence は概ね **0.10〜0.25** に分布し、ゲームによって max が **0.24〜0.58** と大きく振れる。

これは Random Forest を 52 クラス分類で使う構造上の制約(200本の木の票が複数候補に分散)であり、データ追加では緩やかにしか改善しない。閾値 0.5 では複数ゲーム連続で adopt 件数ゼロが継続。

## Diff

\`\`\`diff
-const ML_CONFIDENCE_THRESHOLD = 0.5
+const ML_CONFIDENCE_THRESHOLD = 0.2
\`\`\`

## 期待効果

| 指標 | Before (0.5) | After (0.2) |
|---|---|---|
| 直近サンプルゲームの adopt 率 | 0% | **~20%** |
| 「ML 推論が実プレイで動く」観察 | 不可 | **可能** |
| AI が弱くなるリスク | — | 限定的(top-3 accuracy 52% で「正解に近い手」が多い) |

## tradeoff

- 信頼度が低い予測も採用されるため、AI が「変な手を選ぶ」場面が増える可能性
- 残り 60-80% は引き続き既存 hybrid/MCTS にフォールバック
- データ拡充・キャリブレーション・モデル差し替えで confidence 分布が改善したら段階的に 0.3 → 0.5 → 0.6 へ戻す

## テスト更新

新閾値 0.2 に合わせて「閾値未満で fallback」検証2件の confidence 値を下げる:

| Before | After | 用途 |
|---|---|---|
| 0.4 | **0.15** | single-candidate fallback test |
| top-k 0.3 | **0.1** | top-k all-below-threshold test |

その他の adopt 系テスト (0.75, 0.9, 0.95) は閾値変更の影響なし。

## Test plan

- [x] \`pnpm jest tests/lib/ai/selectAICardWithML.test.ts\` → 7/7 pass
- [x] \`pnpm tsc --noEmit\` → 0 errors
- [x] pre-commit hook (Biome / TS / Jest) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- c5d12bb chore(ml): lower ML_CONFIDENCE_THRESHOLD from 0.5 to 0.2

## 📁 Files Changed

**Total files changed: 2**

- 🔧 **Source Code**: 1 files
- 🧪 **Tests**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/lib/ai/selectAICardWithML.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/ai/aiStrategy.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout chore/ml-threshold-0.2
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*