### PR TITLE
feat(ml): calibrate RF probabilities with isotonic regression

### DIFF
--- a/python/app.py
+++ b/python/app.py
@@ -121,7 +121,8 @@ def _predict(request: PredictRequest, top_k: int = 5) -> PredictResponse:
 
     proba = model.predict_proba(X)[0]
     full = np.zeros(52)
-    for col_idx, cls in enumerate(model.classes_):
+    # model.classes_ は sklearn stub 上 Optional だが fit 後は常に ndarray。
+    for col_idx, cls in enumerate(model.classes_):  # pyright: ignore[reportArgumentType]
         full[cls] = proba[col_idx]
 
     # Restrict to cards actually in hand (model may suggest cards player doesn't hold).

--- a/python/model/train.py
+++ b/python/model/train.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
 import numpy as np
 import skops.io as sio
@@ -122,12 +122,15 @@ def main() -> int:
     )
 
     # CalibratedClassifierCV は feature_importances_ を持たないので、cv 分割した各
-    # base RF の importances を平均する。sklearn の型スタブでは calibrated_classifiers_
-    # の要素や .estimator が Optional 扱いになっており pyright が attribute access で
-    # 文句を言うため、ランタイム上は常にセット済みであることを利用して Any で受ける。
-    fitted_classifiers: Any = model.calibrated_classifiers_
+    # base RF の importances を平均する。sklearn の型スタブは fit 前提の Optional に
+    # なっており pyright が None アクセスを警告するが、fit 後のここでは常にセット済み
+    # のためその行に限り pyright suppress を入れる (Any で受けるとタイポ検出を失うので
+    # ピンポイント抑制を選ぶ)。
     importance_vec = np.mean(
-        [cc.estimator.feature_importances_ for cc in fitted_classifiers],
+        [
+            cc.estimator.feature_importances_  # pyright: ignore[reportOptionalMemberAccess]
+            for cc in model.calibrated_classifiers_
+        ],
         axis=0,
     )
     importances = sorted(

--- a/python/model/train.py
+++ b/python/model/train.py
@@ -122,9 +122,13 @@ def main() -> int:
     )
 
     # CalibratedClassifierCV は feature_importances_ を持たないので、cv 分割した各
-    # base RF の importances を平均する。
+    # base RF の importances を平均する。cc.estimator は型上 BaseEstimator | None だが、
+    # fit 後は必ず RandomForestClassifier がセットされているため cast で narrow する。
     importance_vec = np.mean(
-        [cc.estimator.feature_importances_ for cc in model.calibrated_classifiers_],
+        [
+            cast(RandomForestClassifier, cc.estimator).feature_importances_
+            for cc in model.calibrated_classifiers_
+        ],
         axis=0,
     )
     importances = sorted(

--- a/python/model/train.py
+++ b/python/model/train.py
@@ -9,6 +9,7 @@ from typing import cast
 
 import numpy as np
 import skops.io as sio
+from sklearn.calibration import CalibratedClassifierCV
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.metrics import accuracy_score, top_k_accuracy_score
 from sklearn.model_selection import GroupShuffleSplit
@@ -65,14 +66,26 @@ def main() -> int:
 
     logger.info("Train: %d rows, Test: %d rows", X_train.shape[0], X_test.shape[0])
 
-    logger.info("Training RandomForestClassifier(n_estimators=200, max_depth=12)...")
+    # Random Forest を CalibratedClassifierCV(isotonic) でラップして確信度を再較正する。
+    # 素の RF は 52 クラス分類で票が分散し、top-1 confidence が 0.10〜0.20 に張り付いて
+    # しまうため (Phase 4.2 観察)、isotonic regression で確率を再マッピングし、適切な
+    # 手については閾値 (0.2) を超えやすくする。cv=3 で fit 時間は約 3 倍になる。
+    logger.info(
+        "Training CalibratedClassifierCV(RF n_estimators=200, max_depth=12, cv=3, isotonic)..."
+    )
     t0 = time.perf_counter()
-    model = RandomForestClassifier(
+    base_rf = RandomForestClassifier(
         n_estimators=200,
         max_depth=12,
         min_samples_leaf=2,
         n_jobs=-1,
         random_state=42,
+    )
+    model = CalibratedClassifierCV(
+        estimator=base_rf,
+        method="isotonic",
+        cv=3,
+        n_jobs=-1,
     )
     model.fit(X_train, y_train)
     fit_seconds = time.perf_counter() - t0
@@ -90,14 +103,32 @@ def main() -> int:
     top3 = top_k_accuracy_score(y_test, proba_full, k=3, labels=labels)
     top5 = top_k_accuracy_score(y_test, proba_full, k=5, labels=labels)
 
+    # 閾値 0.2 運用に対する効果を確認するため、テストセットの top-1 confidence の分布を出力する。
+    top1_conf = y_proba.max(axis=1)
+    pct_above_02 = float((top1_conf >= 0.2).mean()) * 100
+    pct_above_03 = float((top1_conf >= 0.3).mean()) * 100
+
     logger.info("=== Evaluation ===")
     logger.info("Accuracy:       %.2f%%", accuracy * 100)
     logger.info("Top-3 Accuracy: %.2f%%", top3 * 100)
     logger.info("Top-5 Accuracy: %.2f%%", top5 * 100)
     logger.info("Baseline (random over 52): %.2f%%", (1 / 52) * 100)
+    logger.info(
+        "Top-1 confidence: mean=%.3f, median=%.3f, >=0.2=%.1f%%, >=0.3=%.1f%%",
+        float(top1_conf.mean()),
+        float(np.median(top1_conf)),
+        pct_above_02,
+        pct_above_03,
+    )
 
+    # CalibratedClassifierCV は feature_importances_ を持たないので、cv 分割した各
+    # base RF の importances を平均する。
+    importance_vec = np.mean(
+        [cc.estimator.feature_importances_ for cc in model.calibrated_classifiers_],
+        axis=0,
+    )
     importances = sorted(
-        zip(FEATURE_NAMES, model.feature_importances_, strict=True),
+        zip(FEATURE_NAMES, importance_vec, strict=True),
         key=lambda t: t[1],
         reverse=True,
     )

--- a/python/model/train.py
+++ b/python/model/train.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import skops.io as sio
@@ -122,13 +122,12 @@ def main() -> int:
     )
 
     # CalibratedClassifierCV は feature_importances_ を持たないので、cv 分割した各
-    # base RF の importances を平均する。cc.estimator は型上 BaseEstimator | None だが、
-    # fit 後は必ず RandomForestClassifier がセットされているため cast で narrow する。
+    # base RF の importances を平均する。sklearn の型スタブでは calibrated_classifiers_
+    # の要素や .estimator が Optional 扱いになっており pyright が attribute access で
+    # 文句を言うため、ランタイム上は常にセット済みであることを利用して Any で受ける。
+    fitted_classifiers: Any = model.calibrated_classifiers_
     importance_vec = np.mean(
-        [
-            cast(RandomForestClassifier, cc.estimator).feature_importances_
-            for cc in model.calibrated_classifiers_
-        ],
+        [cc.estimator.feature_importances_ for cc in fitted_classifiers],
         axis=0,
     )
     importances = sorted(

--- a/python/model/train.py
+++ b/python/model/train.py
@@ -98,7 +98,8 @@ def main() -> int:
     # top_k_accuracy needs the global label set; pass labels= for safety.
     labels = np.arange(52)
     proba_full = np.zeros((y_proba.shape[0], 52))
-    for col_idx, cls in enumerate(model.classes_):
+    # model.classes_ は sklearn stub 上 Optional だが fit 後は常に ndarray。
+    for col_idx, cls in enumerate(model.classes_):  # pyright: ignore[reportArgumentType]
         proba_full[:, cls] = y_proba[:, col_idx]
     top3 = top_k_accuracy_score(y_test, proba_full, k=3, labels=labels)
     top5 = top_k_accuracy_score(y_test, proba_full, k=5, labels=labels)


### PR DESCRIPTION
## Summary

- Wrap `RandomForestClassifier` in `CalibratedClassifierCV(method='isotonic', cv=3)` so top-1 confidence is no longer compressed into the 0.10〜0.20 range that RF produces with 52-class voting
- Goal: lift ML adoption rate from the post-#347 baseline (~11% / game) without changing the 0.2 threshold or other code

## Motivation

After #347 lowered the threshold from 0.5 → 0.2, the first real-play game showed:

| outcome | count | note |
|---|---|---|
| adopt | 3 | confidence 0.20〜0.28 (barely over threshold) |
| fallback (low-conf) | 24 | mostly 0.03〜0.18; several at 0.18〜0.19 |
| skip (1-playable) | 6 | trivial |

So the gap is **the distribution's shape**, not the threshold. Isotonic calibration re-maps RF probabilities onto a non-parametric monotonic function fit on held-out folds, typically spreading "correct" predictions higher while keeping uncertain ones low.

## What changes

- `python/model/train.py`:
  - Wrap base RF with `CalibratedClassifierCV(estimator=base_rf, method='isotonic', cv=3, n_jobs=-1)` — fit time ≈ 3×
  - Log top-1 confidence distribution (mean / median / ≥0.2 / ≥0.3) so the calibration effect is visible from training output alone
  - Average `feature_importances_` across `cv` splits since `CalibratedClassifierCV` does not expose the attribute directly
- `app.py` unchanged — `predict_proba` and `classes_` are preserved by `CalibratedClassifierCV`
- Threshold stays at **0.2** (per user request)

## Test plan

- [x] `ruff check` and `black --check` pass on `train.py`
- [x] Pre-commit (tsc + jest) pass
- [ ] After merge → retrain via HF Space UI → verify training log shows the new "Top-1 confidence" line, ideally with `>=0.2` ≥ 20%
- [ ] Play 1 game with `vercel dev` → count `[aiStrategy.ml] adopt` events; expect noticeably more than the ~3 per game observed under #347 alone

## Notes

- isotonic vs sigmoid: isotonic is non-parametric and tends to work better for tree-based estimators with skewed output distributions; sigmoid (Platt) would compress further, which is the opposite of what we want here
- Training data volume (~20K rows / 52 classes ≈ 380 positives per class binary) is on the lower edge for isotonic but should be sufficient

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- b7bb786 fix(ml): pinpoint-suppress pyright Optional warning on model.classes_
- 3deb374 fix(ml): use targeted pyright ignore instead of Any for stub false positive
- bf89a38 fix(ml): silence pyright by typing fitted classifiers as Any
- cbf90c0 fix(ml): narrow CalibratedClassifierCV.estimator type with cast
- ac084ed feat(ml): calibrate RF probabilities with isotonic regression

## 📁 Files Changed

**Total files changed: 2**

- 📄 **Other**: 2 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files

- `python/app.py`
- `python/model/train.py`

</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*