### PR TITLE
test(ml): Python unit tests + .env-free sim runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,4 +126,5 @@ python/.ruff_cache/
 python/.pytest_cache/
 python/model/models/*.pkl
 python/model/models/*.joblib
+python/model/models/*.skops
 *.pyc

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:check": "npx @biomejs/biome format .",
     "test": "jest",
     "test:ci": "NEXT_PUBLIC_SUPABASE_URL=https://mock.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=mock_anon_key SUPABASE_SERVICE_ROLE_KEY=mock_service_role_key NODE_ENV=test jest --passWithNoTests --clearCache",
-    "sim": "tsx scripts/simulate-games.ts",
+    "sim": "node scripts/run-sim.js",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:e2e": "node tests/setup-test-directories.js && playwright test",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,15 @@ dev = [
   "black>=25",
   "pip-audit>=2.7.3",
   "ruff>=0.8.4",
+  "pytest>=8",
 ]
+
+[tool.pytest.ini_options]
+# Tests import the `model` and `data` packages as top-level, mirroring how
+# train.py / app.py import them at runtime. Put python/ on sys.path.
+pythonpath = ["."]
+testpaths = ["tests"]
+addopts = "-q"
 
 [tool.uv]
 # Supply chain attack mitigation: skip packages published in the last 7 days.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -35,7 +35,9 @@ addopts = "-q"
 [tool.uv]
 # Supply chain attack mitigation: skip packages published in the last 7 days.
 # Aligns with the project-wide minimumReleaseAge=10080 policy used by pnpm.
-exclude-newer = "2026-05-25T00:00:00Z"
+# Bumped to admit pip 26.1.2 (PYSEC-2026-196 fix, published 2026-05-31); still
+# only allows packages aged >= 7 days.
+exclude-newer = "2026-06-01T00:00:00Z"
 
 [tool.ruff]
 # Formatting is delegated to black; ruff handles lint only.

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -29,6 +29,7 @@ charset-normalizer==3.4.7
     # via requests
 click==8.4.1
     # via
+    #   huggingface-hub
     #   pyiceberg
     #   typer
     #   uvicorn
@@ -54,7 +55,7 @@ fsspec==2026.4.0
     #   gradio-client
     #   huggingface-hub
     #   pyiceberg
-gradio==6.14.0
+gradio==6.15.2
     # via napoleon-ml-trainer
 gradio-client==2.5.0
     # via
@@ -76,7 +77,7 @@ hpack==4.1.0
     # via h2
 httpcore==1.0.9
     # via httpx
-httptools==0.7.1
+httptools==0.8.0
     # via uvicorn
 httpx==0.28.1
     # via
@@ -89,13 +90,13 @@ httpx==0.28.1
     #   supabase
     #   supabase-auth
     #   supabase-functions
-huggingface-hub==1.16.1
+huggingface-hub==1.17.0
     # via
     #   gradio
     #   gradio-client
 hyperframe==6.1.0
     # via h2
-idna==3.16
+idna==3.17
     # via
     #   anyio
     #   httpx
@@ -181,7 +182,7 @@ python-dotenv==1.2.2
     # via
     #   napoleon-ml-trainer
     #   uvicorn
-python-multipart==0.0.29
+python-multipart==0.0.30
     # via gradio
 pytz==2026.2
     # via gradio
@@ -216,7 +217,7 @@ six==1.17.0
     # via python-dateutil
 skops==0.14.0
     # via napoleon-ml-trainer
-starlette==1.1.0
+starlette==1.2.1
     # via
     #   fastapi
     #   gradio

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Shared fixtures for the ML trainer test suite.
+
+Data factories live in tests/factories.py; this module only exposes fixtures.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from tests.factories import make_training_df
+
+
+@pytest.fixture
+def training_df() -> pd.DataFrame:
+    return make_training_df()

--- a/python/tests/factories.py
+++ b/python/tests/factories.py
@@ -1,0 +1,78 @@
+"""Test data factories for the ML trainer suite.
+
+Kept separate from conftest.py so test modules can import these helpers
+directly without re-importing the conftest plugin under a second module name.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# {suit, rank, value}-shaped cards, mirroring what the Next.js side stores.
+CARD_SPADES_A = {"suit": "spades", "rank": "A", "value": 14}
+CARD_HEARTS_K = {"suit": "hearts", "rank": "K", "value": 13}
+CARD_DIAMONDS_7 = {"suit": "diamonds", "rank": "7", "value": 7}
+CARD_CLUBS_2 = {"suit": "clubs", "rank": "2", "value": 2}
+
+# Four distinct "selected_card" targets — kept small so CalibratedClassifierCV's
+# internal cv folds have enough samples per class in the train-path test.
+TARGET_CARDS = [CARD_SPADES_A, CARD_HEARTS_K, CARD_DIAMONDS_7, CARD_CLUBS_2]
+
+
+def make_row(
+    *,
+    game_id: str = "game-1",
+    player_id: str = "player-1",
+    trick_number: int = 1,
+    hand: list[dict] | None = None,
+    table_cards: list[dict] | None = None,
+    current_suit: str | None = "spades",
+    trump_suit: str | None = "hearts",
+    selected_card: dict | None = None,
+    role: str = "napoleon",
+    is_napoleon_team: bool = True,
+    game_result: str | None = "napoleon_win",
+    player_final_score: int | None = 10,
+    is_ai_player: bool = True,
+    ai_difficulty: str | None = "normal",
+) -> dict:
+    """Build one ml_training_data row matching the Supabase schema."""
+    return {
+        "game_id": game_id,
+        "player_id": player_id,
+        "trick_number": trick_number,
+        "hand": hand if hand is not None else [CARD_SPADES_A, CARD_HEARTS_K],
+        "table_cards": table_cards if table_cards is not None else [],
+        "current_suit": current_suit,
+        "trump_suit": trump_suit,
+        "selected_card": selected_card if selected_card is not None else CARD_SPADES_A,
+        "game_phase": "playing",
+        "role": role,
+        "is_napoleon_team": is_napoleon_team,
+        "game_result": game_result,
+        "player_final_score": player_final_score,
+        "is_ai_player": is_ai_player,
+        "ai_difficulty": ai_difficulty,
+    }
+
+
+def make_training_df(n_games: int = 4, rows_per_game: int = 16) -> pd.DataFrame:
+    """Build a synthetic, well-formed training DataFrame.
+
+    Targets cycle through TARGET_CARDS so every class is represented many times,
+    which keeps CalibratedClassifierCV(cv=3) happy on small data.
+    """
+    rows: list[dict] = []
+    for g in range(n_games):
+        for i in range(rows_per_game):
+            target = TARGET_CARDS[(g * rows_per_game + i) % len(TARGET_CARDS)]
+            rows.append(
+                make_row(
+                    game_id=f"game-{g}",
+                    player_id=f"player-{i % 4}",
+                    trick_number=(i % 12) + 1,
+                    selected_card=target,
+                    hand=[target, CARD_DIAMONDS_7, CARD_CLUBS_2],
+                )
+            )
+    return pd.DataFrame(rows)

--- a/python/tests/test_features.py
+++ b/python/tests/test_features.py
@@ -1,0 +1,169 @@
+"""Unit tests for model.features (feature engineering)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from model.features import (
+    FEATURE_NAMES,
+    HIGH_RANKS,
+    RANK_TO_IDX,
+    ROLES,
+    SUITS,
+    build_feature_matrix,
+    card_class_index,
+    card_id,
+    class_index_to_card_id,
+)
+from tests.factories import CARD_HEARTS_K, CARD_SPADES_A, make_row
+
+
+def test_card_id_format():
+    assert card_id({"suit": "spades", "rank": "A"}) == "spades-A"
+    assert card_id({"suit": "clubs", "rank": "10"}) == "clubs-10"
+
+
+def test_card_class_index_range_and_uniqueness():
+    """Every (suit, rank) maps to a distinct index in 0..51."""
+    seen = set()
+    for suit in SUITS:
+        for rank in RANK_TO_IDX:
+            idx = card_class_index({"suit": suit, "rank": rank})
+            assert 0 <= idx < 52
+            seen.add(idx)
+    assert len(seen) == 52
+
+
+def test_card_class_index_known_values():
+    # spades is suit 0, rank "2" is rank 0 -> index 0.
+    assert card_class_index({"suit": "spades", "rank": "2"}) == 0
+    # clubs is suit 3, rank "A" is rank 12 -> 3*13 + 12 = 51.
+    assert card_class_index({"suit": "clubs", "rank": "A"}) == 51
+
+
+def test_class_index_round_trip():
+    """card_class_index and class_index_to_card_id are inverse for all 52."""
+    for suit in SUITS:
+        for rank in RANK_TO_IDX:
+            idx = card_class_index({"suit": suit, "rank": rank})
+            assert class_index_to_card_id(idx) == f"{suit}-{rank}"
+
+
+def test_feature_names_length_matches_vector():
+    """The produced feature vector width equals len(FEATURE_NAMES)."""
+    df = pd.DataFrame([make_row()])
+    X, _ = build_feature_matrix(df)
+    assert X.shape == (1, len(FEATURE_NAMES))
+
+
+def test_build_feature_matrix_shape_dtype_and_labels():
+    rows = [
+        make_row(selected_card=CARD_SPADES_A),
+        make_row(selected_card=CARD_HEARTS_K),
+    ]
+    df = pd.DataFrame(rows)
+    X, y = build_feature_matrix(df)
+
+    assert X.shape == (2, len(FEATURE_NAMES))
+    assert X.dtype == np.float32
+    assert y.dtype == np.int64
+    assert y[0] == card_class_index(CARD_SPADES_A)
+    assert y[1] == card_class_index(CARD_HEARTS_K)
+
+
+def _features_as_dict(row: dict) -> dict:
+    df = pd.DataFrame([row])
+    X, _ = build_feature_matrix(df)
+    return dict(zip(FEATURE_NAMES, X[0], strict=True))
+
+
+def test_hand_suit_and_high_counts():
+    hand = [
+        {"suit": "spades", "rank": "A", "value": 14},
+        {"suit": "spades", "rank": "K", "value": 13},
+        {"suit": "hearts", "rank": "Q", "value": 12},
+    ]
+    feats = _features_as_dict(make_row(hand=hand))
+    assert feats["hand_size"] == 3
+    assert feats["hand_count_spades"] == 2
+    assert feats["hand_count_hearts"] == 1
+    assert feats["hand_count_diamonds"] == 0
+    # High-card counts (J/Q/K/A).
+    assert feats["hand_count_A"] == 1
+    assert feats["hand_count_K"] == 1
+    assert feats["hand_count_Q"] == 1
+    assert feats["hand_count_J"] == 0
+    assert feats["hand_max_value"] == 14
+    assert feats["hand_min_value"] == 12
+
+
+def test_empty_hand_sets_min_value_zero():
+    feats = _features_as_dict(make_row(hand=[]))
+    assert feats["hand_size"] == 0
+    assert feats["hand_min_value"] == 0
+    assert feats["hand_max_value"] == 0
+
+
+def test_role_one_hot_is_exclusive():
+    for role in ROLES:
+        feats = _features_as_dict(make_row(role=role))
+        active = [feats[f"role_{r}"] for r in ROLES]
+        assert sum(active) == 1
+        assert feats[f"role_{role}"] == 1
+
+
+def test_null_suit_flags_and_one_hot():
+    feats = _features_as_dict(make_row(current_suit=None, trump_suit=None))
+    assert feats["current_suit_null"] == 1
+    assert feats["trump_suit_null"] == 1
+    assert all(feats[f"current_suit_{s}"] == 0 for s in SUITS)
+    assert all(feats[f"trump_suit_{s}"] == 0 for s in SUITS)
+
+
+def test_current_suit_one_hot_and_null_flag_when_set():
+    feats = _features_as_dict(make_row(current_suit="hearts"))
+    assert feats["current_suit_null"] == 0
+    assert feats["current_suit_hearts"] == 1
+    assert feats["current_suit_spades"] == 0
+
+
+def test_has_lead_suit_in_hand():
+    hand = [{"suit": "hearts", "rank": "5", "value": 5}]
+    assert (
+        _features_as_dict(make_row(hand=hand, current_suit="hearts"))["has_lead_suit_in_hand"] == 1
+    )
+    assert (
+        _features_as_dict(make_row(hand=hand, current_suit="spades"))["has_lead_suit_in_hand"] == 0
+    )
+    # With no lead suit, the flag is 0 regardless of hand.
+    assert _features_as_dict(make_row(hand=hand, current_suit=None))["has_lead_suit_in_hand"] == 0
+
+
+def test_table_lead_max_only_counts_lead_suit():
+    table = [
+        {"suit": "spades", "rank": "K", "value": 13},
+        {"suit": "hearts", "rank": "A", "value": 14},
+    ]
+    feats = _features_as_dict(make_row(table_cards=table, current_suit="spades"))
+    assert feats["table_size"] == 2
+    # Highest overall value on the table is the off-suit hearts A (14)...
+    assert feats["table_max_value"] == 14
+    # ...but the lead-suit (spades) max is only the spades K (13).
+    assert feats["table_lead_max_value"] == 13
+
+
+def test_is_napoleon_team_and_trick_number_passthrough():
+    feats = _features_as_dict(make_row(is_napoleon_team=True, trick_number=7))
+    assert feats["is_napoleon_team"] == 1
+    assert feats["trick_number"] == 7
+    feats2 = _features_as_dict(make_row(is_napoleon_team=False))
+    assert feats2["is_napoleon_team"] == 0
+
+
+@pytest.mark.parametrize("rank", HIGH_RANKS)
+def test_each_high_rank_counted(rank):
+    hand = [{"suit": "spades", "rank": rank, "value": 10}]
+    feats = _features_as_dict(make_row(hand=hand))
+    assert feats[f"hand_count_{rank}"] == 1

--- a/python/tests/test_fetch_data.py
+++ b/python/tests/test_fetch_data.py
@@ -1,0 +1,172 @@
+"""Unit tests for data.fetch_data (credentials guard + pagination)."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import data.fetch_data as fetch
+from tests.factories import make_training_df
+
+_ENV_VARS = (
+    "SUPABASE_URL",
+    "SUPABASE_ANON_KEY",
+    "NEXT_PUBLIC_SUPABASE_URL",
+    "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Never touch the real python/.env and start from a clean env."""
+    monkeypatch.setattr(fetch, "_load_env", lambda: None)
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_get_supabase_client_raises_without_credentials():
+    with pytest.raises(RuntimeError, match="Missing Supabase credentials"):
+        fetch.get_supabase_client()
+
+
+def test_get_supabase_client_uses_public_env_fallback(monkeypatch):
+    """NEXT_PUBLIC_* vars are accepted when the unprefixed ones are absent."""
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_URL", "https://example.supabase.co")
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "anon-key-123")
+
+    captured = {}
+
+    def fake_create_client(url, key):
+        captured["url"] = url
+        captured["key"] = key
+        return "CLIENT"
+
+    monkeypatch.setattr(fetch, "create_client", fake_create_client)
+
+    client = fetch.get_supabase_client()
+    assert client == "CLIENT"
+    assert captured == {"url": "https://example.supabase.co", "key": "anon-key-123"}
+
+
+def test_get_supabase_client_prefers_unprefixed_env(monkeypatch):
+    monkeypatch.setenv("SUPABASE_URL", "https://primary.supabase.co")
+    monkeypatch.setenv("SUPABASE_ANON_KEY", "primary-key")
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_URL", "https://fallback.supabase.co")
+    monkeypatch.setenv("NEXT_PUBLIC_SUPABASE_ANON_KEY", "fallback-key")
+
+    captured = {}
+    monkeypatch.setattr(
+        fetch,
+        "create_client",
+        lambda url, key: captured.update(url=url, key=key) or "CLIENT",
+    )
+
+    fetch.get_supabase_client()
+    assert captured["url"] == "https://primary.supabase.co"
+    assert captured["key"] == "primary-key"
+
+
+class _FakeResp:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeQuery:
+    """Records the query-builder calls and serves paginated slices."""
+
+    def __init__(self, data):
+        self._data = data
+        self._start = 0
+        self._end = 0
+        self.calls: list[str] = []
+
+    def select(self, _cols):
+        self.calls.append("select")
+        return self
+
+    @property
+    def not_(self):
+        self.calls.append("not_")
+        return self
+
+    def is_(self, col, val):
+        self.calls.append(f"is_:{col}:{val}")
+        return self
+
+    def order(self, _col):
+        self.calls.append("order")
+        return self
+
+    def range(self, start, end):
+        self._start = start
+        self._end = end
+        return self
+
+    def execute(self):
+        # Supabase range() is inclusive on both ends.
+        return _FakeResp(self._data[self._start : self._end + 1])
+
+
+class _FakeClient:
+    def __init__(self, query):
+        self._query = query
+        self.tables: list[str] = []
+
+    def table(self, name):
+        self.tables.append(name)
+        return self._query
+
+
+def _install_fake_client(monkeypatch, rows):
+    query = _FakeQuery(rows)
+    client = _FakeClient(query)
+    monkeypatch.setattr(fetch, "get_supabase_client", lambda: client)
+    return client, query
+
+
+def test_fetch_training_data_paginates_until_short_batch(monkeypatch):
+    rows = [{"game_id": f"g{i}", "n": i} for i in range(5)]
+    _client, query = _install_fake_client(monkeypatch, rows)
+
+    df = fetch.fetch_training_data(completed_only=False, page_size=2)
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 5
+    # 5 rows / page_size 2 => three execute() round-trips (2, 2, 1).
+    assert query.calls.count("select") == 3
+
+
+def test_fetch_training_data_applies_completed_only_filter(monkeypatch):
+    rows = [{"game_id": "g0", "game_result": "napoleon_win"}]
+    _client, query = _install_fake_client(monkeypatch, rows)
+
+    fetch.fetch_training_data(completed_only=True, page_size=1000)
+    assert "not_" in query.calls
+    assert "is_:game_result:null" in query.calls
+
+
+def test_fetch_training_data_skips_filter_when_not_completed_only(monkeypatch):
+    rows = [{"game_id": "g0", "game_result": None}]
+    _client, query = _install_fake_client(monkeypatch, rows)
+
+    fetch.fetch_training_data(completed_only=False, page_size=1000)
+    assert "not_" not in query.calls
+    assert all(not c.startswith("is_:") for c in query.calls)
+
+
+def test_fetch_training_data_empty_returns_empty_df(monkeypatch):
+    _client, _query = _install_fake_client(monkeypatch, [])
+    df = fetch.fetch_training_data(completed_only=False, page_size=1000)
+    assert isinstance(df, pd.DataFrame)
+    assert df.empty
+
+
+def test_summarize_handles_empty_df():
+    # Should log-and-return without raising on an empty frame.
+    fetch.summarize(pd.DataFrame())
+
+
+def test_summarize_handles_populated_df():
+    df = make_training_df(n_games=2, rows_per_game=8)
+    # Exercises every value_counts / .loc branch without raising.
+    fetch.summarize(df)

--- a/python/tests/test_train.py
+++ b/python/tests/test_train.py
@@ -1,0 +1,114 @@
+"""Unit tests for model.train (splitting + the training entrypoint)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+import model.train as train
+from tests.factories import make_training_df
+
+
+def _toy_grouped_data():
+    """6 rows across 3 games, 2 rows each."""
+    X = np.arange(12, dtype=np.float64).reshape(6, 2)
+    y = np.array([0, 1, 0, 1, 0, 1])
+    groups = np.array(["g0", "g0", "g1", "g1", "g2", "g2"])
+    return X, y, groups
+
+
+def test_split_by_game_keeps_games_on_one_side():
+    X, y, groups = _toy_grouped_data()
+    X_train, X_test, y_train, y_test = train.split_by_game(X, y, groups, test_size=0.34)
+
+    # Map each row back to its game via the first feature column (0..11 step 2).
+    def games_of(rows):
+        return {groups[int(r[0]) // 2] for r in rows}
+
+    train_games = games_of(X_train)
+    test_games = games_of(X_test)
+    assert train_games.isdisjoint(test_games)
+    assert train_games | test_games == {"g0", "g1", "g2"}
+
+
+def test_split_by_game_preserves_row_count():
+    X, y, groups = _toy_grouped_data()
+    X_train, X_test, y_train, y_test = train.split_by_game(X, y, groups)
+    assert X_train.shape[0] + X_test.shape[0] == X.shape[0]
+    assert y_train.shape[0] + y_test.shape[0] == y.shape[0]
+    assert X_train.shape[1] == X.shape[1]
+
+
+def test_split_by_game_is_deterministic():
+    X, y, groups = _toy_grouped_data()
+    a = train.split_by_game(X, y, groups, seed=7)
+    b = train.split_by_game(X, y, groups, seed=7)
+    for left, right in zip(a, b, strict=True):
+        np.testing.assert_array_equal(left, right)
+
+
+def test_main_returns_error_on_insufficient_data(monkeypatch):
+    """Fewer than 50 rows must abort early with exit code 1."""
+    small = make_training_df(n_games=1, rows_per_game=10)  # 10 rows
+    assert len(small) < 50
+    monkeypatch.setattr(train, "fetch_training_data", lambda: small)
+    dumped: list = []
+    monkeypatch.setattr(train.sio, "dump", lambda *a, **k: dumped.append(a))
+
+    assert train.main() == 1
+    assert dumped == []  # never reached the save step
+
+
+def test_main_trains_and_saves_model(monkeypatch):
+    """Happy path: enough data -> trains, evaluates, saves with metadata."""
+    df = make_training_df(n_games=4, rows_per_game=16)  # 64 rows, 4 classes
+    monkeypatch.setattr(train, "fetch_training_data", lambda: df)
+
+    captured: dict = {}
+
+    def fake_dump(obj, path):
+        captured["obj"] = obj
+        captured["path"] = path
+
+    monkeypatch.setattr(train.sio, "dump", fake_dump)
+
+    rc = train.main()
+    assert rc == 0
+
+    payload = captured["obj"]
+    # Metadata contract consumed by app.py at inference time.
+    for key in (
+        "model",
+        "feature_names",
+        "trained_rows",
+        "test_rows",
+        "accuracy",
+        "top3_accuracy",
+    ):
+        assert key in payload
+    assert payload["feature_names"] == train.FEATURE_NAMES
+    assert 0.0 <= payload["accuracy"] <= 1.0
+    assert 0.0 <= payload["top3_accuracy"] <= 1.0
+    assert payload["trained_rows"] > 0
+    assert payload["test_rows"] > 0
+    # The fitted model can score the feature matrix it was trained on.
+    X, _ = train.build_feature_matrix(df)
+    assert payload["model"].predict(X).shape == (len(df),)
+
+
+def test_main_handles_few_games_with_row_split(monkeypatch):
+    """With <5 games the code falls back to a row-wise split (still trains)."""
+    df = make_training_df(n_games=2, rows_per_game=30)  # 60 rows, 2 games
+    assert df["game_id"].nunique() < 5
+    monkeypatch.setattr(train, "fetch_training_data", lambda: df)
+    monkeypatch.setattr(train.sio, "dump", lambda *a, **k: None)
+
+    assert train.main() == 0
+
+
+def test_build_feature_matrix_reexported_from_train():
+    """train re-uses features.build_feature_matrix; sanity check the wiring."""
+    df = pd.DataFrame(make_training_df(n_games=1, rows_per_game=4))
+    X, y = train.build_feature_matrix(df)
+    assert X.shape[0] == 4
+    assert y.shape[0] == 4

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-25T00:00:00Z"
+exclude-newer = "2026-06-01T00:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -345,7 +345,7 @@ wheels = [
 
 [[package]]
 name = "gradio"
-version = "6.14.0"
+version = "6.15.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -377,9 +377,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/bd/7d1544571de4566138e50c868b91bb79e38c998266896d38fed3d3a77898/gradio-6.14.0.tar.gz", hash = "sha256:4972ef7d01ac57472772624eb4e095767b6c8f3cd4846b7fea648e8034cda9f8", size = 36026409, upload-time = "2026-04-30T16:50:31.698Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/6d/a8b16b2bd3547c9d9da9656242d350481ffbedc97e3d8fc4eb939448be55/gradio-6.15.2.tar.gz", hash = "sha256:67433b1889dc8526658196277ca9e34109f73aa65656635c0dc6afb542571f55", size = 36432997, upload-time = "2026-05-28T19:25:52.409Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/e2/41f991b2e212b7afda3a9927676ebf8af302e5a2c632b330bd70bf2cf2c1/gradio-6.14.0-py3-none-any.whl", hash = "sha256:bb702f5ab643510d167bae54269ad6e985c2185174d388fe542cc5957f51f4fd", size = 19687959, upload-time = "2026-04-30T16:50:26.914Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/43/2f9827ea758ef70fcc23e2c468dd5ef208352b1a56d4446d680df2e4fc1a/gradio-6.15.2-py3-none-any.whl", hash = "sha256:3492eee59cbe4afd21e8f458fc229f0d92c17bdaacaefaf9580dd63a6406c82d", size = 20094003, upload-time = "2026-05-28T19:25:48.489Z" },
 ]
 
 [[package]]
@@ -490,17 +490,17 @@ wheels = [
 
 [[package]]
 name = "httptools"
-version = "0.7.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
 ]
 
 [[package]]
@@ -525,9 +525,10 @@ http2 = [
 
 [[package]]
 name = "huggingface-hub"
-version = "1.16.1"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
@@ -538,9 +539,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/65/9826515abb600b5722bcf53f8b4a2fb58340b1f8bfcaee19f83561c13a44/huggingface_hub-1.17.0.tar.gz", hash = "sha256:fad842b6763ef70ebc3919665b1b9273645203185400a7d6c5eddc2323cc3435", size = 797082, upload-time = "2026-05-28T15:12:13.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+    { url = "https://files.pythonhosted.org/packages/02/28/d7cef5e477b855c25d415b8f57e5bc7347c7a90cad3acf1725d0c92ca294/huggingface_hub-1.17.0-py3-none-any.whl", hash = "sha256:3b8156d23118e87f6a587648bfbc04f04a12a757ccb4ed298b35c4ae638bf24c", size = 671546, upload-time = "2026-05-28T15:12:11.441Z" },
 ]
 
 [[package]]
@@ -554,11 +555,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]
@@ -945,11 +946,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -1000,11 +1001,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -1277,11 +1278,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.29"
+version = "0.0.30"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/82/c8cd43a6e0719bf5a3b034f6726dd701f75829c08944c83d4b95d02ed0e8/python_multipart-0.0.30.tar.gz", hash = "sha256:0edfe0475c1f46ddd3ff7785a626f6118af32bdcf359bb21260367313bb32118", size = 46316, upload-time = "2026-05-31T19:24:55.198Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fd/0318007beb234790993d3ec5afd051d1dbceb733e81e3afe2b981ece3f37/python_multipart-0.0.30-py3-none-any.whl", hash = "sha256:830964def8c90607ac5daa00514e3987815865713ade8d20febc9177ac0c3c5b", size = 29730, upload-time = "2026-05-31T19:24:53.814Z" },
 ]
 
 [[package]]
@@ -1369,27 +1370,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.14"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
-    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
-    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]
@@ -1515,14 +1516,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.1.0"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -562,6 +562,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -767,6 +776,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "pip-audit" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -789,6 +799,7 @@ requires-dist = [
 dev = [
     { name = "black", specifier = ">=25" },
     { name = "pip-audit", specifier = ">=2.7.3" },
+    { name = "pytest", specifier = ">=8" },
     { name = "ruff", specifier = ">=0.8.4" },
 ]
 
@@ -994,6 +1005,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1216,6 +1236,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/a1/03250fd4834b6a5c13e6600bca47ea20fda579f80bce3551d4985185d164/pyroaring-1.1.0-cp313-cp313-win32.whl", hash = "sha256:eead129046822cb0fd47c78740b81bdaffd0515c0bb0306a2318acf0f0540b58", size = 211194, upload-time = "2026-04-24T21:28:35.001Z" },
     { url = "https://files.pythonhosted.org/packages/70/63/d9b307462cddc82fe94a67d6810e5c802818690e131ba690c1de674d8558/pyroaring-1.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:90ab2f00c09eed5bd986a80c8641e2dc10e7aca1a2d892d89a44b396e39c08ea", size = 263110, upload-time = "2026-04-24T21:28:35.976Z" },
     { url = "https://files.pythonhosted.org/packages/d9/4a/aa6e9833a6ba9a630efdbec8783b63da6602f763b37a5b5fbc01d73a1af1/pyroaring-1.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:51dd2490a64ad4ed53c4fb58ef1ee3f84f6cbd97cdb47abd9065c9f714ab72ef", size = 216546, upload-time = "2026-04-24T21:28:37.065Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]

--- a/scripts/run-sim.js
+++ b/scripts/run-sim.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+// ヘッドレス AI 対 AI シミュレータ (scripts/simulate-games.ts) のラッパー。
+//
+// 方針: ローカルに永続的な .env を置かない (vercel dev / Vercel 管理で一元化)。
+// そのため Supabase 認証情報は実行のたびに `vercel env pull` で OS の一時ファイル
+// にだけ取得し、実行後に必ず削除する。リポジトリ内には env ファイルを残さない。
+//
+// すでに環境変数が注入されている場合 (vercel dev 経由・CI・手動 export) は
+// pull をスキップしてそのまま実行する。
+//
+// Usage:
+//   pnpm sim          # 1 game
+//   pnpm sim 200      # 200 games
+//   NEXT_PUBLIC_AI_DIFFICULTY=hard pnpm sim 100
+
+const { spawnSync } = require('node:child_process')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const SIM_SCRIPT = path.join(__dirname, 'simulate-games.ts')
+const passthroughArgs = process.argv.slice(2)
+
+// シミュレータが必要とする最低限の認証情報。両方そろっていれば pull 不要。
+const hasCreds =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.SUPABASE_SERVICE_ROLE_KEY
+
+function runTsx(extraArgs) {
+  const result = spawnSync(
+    'pnpm',
+    ['exec', 'tsx', ...extraArgs, SIM_SCRIPT, ...passthroughArgs],
+    { stdio: 'inherit' }
+  )
+  if (result.error) {
+    console.error('[run-sim] failed to launch tsx:', result.error.message)
+    return 1
+  }
+  return result.status ?? 1
+}
+
+function main() {
+  if (hasCreds) {
+    console.log('[run-sim] Supabase env already present — running directly.')
+    process.exit(runTsx([]))
+  }
+
+  // 一時ファイルへ env を pull → --env-file で読ませる → 実行後に必ず削除。
+  // 注意: try/finally で process.exit を呼ぶと finally が走らないため、
+  // 終了コードを変数に保持し、削除を済ませてから最後に exit する。
+  const tmpEnv = path.join(os.tmpdir(), `napoleon-sim-env-${process.pid}`)
+  console.log('[run-sim] Pulling Vercel env to a temp file (not persisted)...')
+
+  const pull = spawnSync(
+    'vercel',
+    ['env', 'pull', tmpEnv, '--environment=development', '--yes'],
+    { stdio: 'inherit' }
+  )
+
+  let status
+  if (pull.error || pull.status !== 0) {
+    console.error(
+      '[run-sim] `vercel env pull` failed. Are you logged in? Try: vercel login'
+    )
+    status = pull.status ?? 1
+  } else {
+    status = runTsx([`--env-file=${tmpEnv}`])
+  }
+
+  // 認証情報を含む一時ファイルを必ず削除する。
+  try {
+    fs.rmSync(tmpEnv, { force: true })
+  } catch (err) {
+    console.warn(
+      `[run-sim] warning: could not remove temp env file ${tmpEnv}: ${err.message}`
+    )
+  }
+
+  process.exit(status)
+}
+
+main()


### PR DESCRIPTION
## 概要

ML trainer (`python/`) の**初のPythonユニットテスト**追加と、データ蓄積用シミュレータを**永続`.env`なし**でワンコマンド実行できるようにするツール改善です。

TS側（`mlClient` / `selectAICardWithML`）はテストが手厚い一方、Python側（features/train/fetch_data）はテスト皆無でした。その唯一の重大な穴を塞ぎます。

> 注: isotonic校正など `feat(ml)` 系は既にdevelopにマージ済みのため、本PRは**テスト＋sim実行ツールのみ**の差分です。

## 変更点

### 🧪 Pythonユニットテスト（34テスト・全pass）
- **`test_features.py`** — card class index の 0..51 全単射・往復変換、特徴ベクトル幅=`FEATURE_NAMES`長・dtype、suit/高位カード枚数、null suit処理、ロールone-hot排他、lead-suit判定、`table_lead_max`のlead-suit限定集計
- **`test_train.py`** — `split_by_game` のゲーム単位リーク防止・決定性・行数保存、データ不足ガード(<50行→exit1)、**実学習happy path**（保存メタデータ契約キー・モデルがpredict可能まで）、<5ゲーム時の行split分岐
- **`test_fetch_data.py`** — 認証情報欠如時の`RuntimeError`、`NEXT_PUBLIC_*`フォールバック、ページネーション停止条件、`completed_only`フィルタのon/off、空結果、`summarize`の空/充填両系統
- pytestをuv devグループに追加 + `pythonpath`設定で `model`/`data` をruntime同様にtop-level import
- ヘルパーは`tests/factories.py`に分離（conftest二重import回避）

### 🤖 sim実行ツール（`scripts/run-sim.js`）
- `pnpm sim` がラッパー経由になり、Supabase認証情報を **OSの一時ファイルにのみ** `vercel env pull` → 実行後に必ず削除。**リポジトリ内に`.env`を残さない**方針を維持
- 既にenv注入済み（`vercel dev`/CI/手動export）なら pull をスキップ

### 🧹 `.gitignore`
- `python/model/models/*.skops` を追加。モデル形式が `.pkl`/`.joblib` → `.skops` に変わった際にignore漏れがあり、学習済みモデル（数百MB〜）が誤コミットされ得たため

## テスト
```
cd python && uv run pytest        # 34 passed
```
ruff / black もクリーン。pre-commit（type-check + jest）通過済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 4989f0d fix(security): bump exclude-newer to pull pip 26.1.2 (PYSEC-2026-196)
- 0083625 chore(sim): run sim without a persistent .env and ignore .skops models
- 27a2018 test(ml): add pytest suite for features, train, and fetch_data

## 📁 Files Changed

**Total files changed: 12**

- 🔧 **Source Code**: 1 files
- 🧪 **Tests**: 1 files
- ⚙️ **Configuration**: 2 files
- 📄 **Other**: 8 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code

- `scripts/run-sim.js`

#### ⚙️ Configuration

- `package.json`
- `python/uv.lock`

#### 📄 Other Files

- `python/tests/__init__.py`
- `python/tests/conftest.py`
- `python/tests/factories.py`
- `python/tests/test_features.py`
- `python/tests/test_fetch_data.py`
- `python/tests/test_train.py`
- `.gitignore`
- `python/pyproject.toml`
- `python/requirements.txt`

</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added
- 💄 **UI/UX** - User interface improvements
- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout chore/ml-python-tests
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*