### PR TITLE
chore(deps): drop uv exclude-newer, rely on Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,8 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Tokyo"
-    # 公開直後のパッケージを避ける (python/pyproject.toml の uv exclude-newer と同等)
+    # 公開直後のパッケージを避ける。Python の供給網保護はこの cooldown が唯一の
+    # ソース（旧 uv exclude-newer はメンテ負荷のため廃止し、ここに一本化）。
     cooldown:
       default-days: 7
       semver-major-days: 14

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,12 +32,12 @@ pythonpath = ["."]
 testpaths = ["tests"]
 addopts = "-q"
 
-[tool.uv]
-# Supply chain attack mitigation: skip packages published in the last 7 days.
-# Aligns with the project-wide minimumReleaseAge=10080 policy used by pnpm.
-# Bumped to admit pip 26.1.2 (PYSEC-2026-196 fix, published 2026-05-31); still
-# only allows packages aged >= 7 days.
-exclude-newer = "2026-06-01T00:00:00Z"
+# NOTE: supply-chain "skip just-published packages" protection is enforced by
+# Dependabot's 7-day cooldown (see .github/dependabot.yml, pip ecosystem), not
+# by a uv `exclude-newer` pin. A pinned date had to be hand-bumped on every
+# refresh (and is also stamped into uv.lock's [options]), so it was dropped in
+# favour of the single Dependabot source of truth. If you ever need a floor for
+# a one-off manual lock, pass `uv lock --exclude-newer <DATE>` explicitly.
 
 [tool.ruff]
 # Formatting is delegated to black; ruff handles lint only.

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -7,9 +7,6 @@ resolution-markers = [
     "sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
-[options]
-exclude-newer = "2026-06-01T00:00:00Z"
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
## 概要

`[tool.uv] exclude-newer`（最近7日以内のパッケージを除外する供給網ガード）は**固定日付しか書けず**、新しい修正版を取り込むたびに手で日付を更新する必要がありました。さらに uv はこの日付を **`uv.lock` の `[options]` にも焼き込む**ため、refresh のたびに「日付だけの差分」が出てPRが必要でした。

同じ「公開直後のパッケージを避ける」保護は、**既に Dependabot の7日 cooldown（pip エコシステム）で担保済み**です（`.github/dependabot.yml`、コメントにも「uv exclude-newer と同等」と明記）。そこで uv のピンを撤廃し、**Dependabot を唯一のソース**に一本化します。

## 変更点

- **`python/pyproject.toml`**: `[tool.uv] exclude-newer` ブロックを削除（コメントで Dependabot cooldown を案内。単発の手動lockで床が要る場合は `uv lock --exclude-newer <DATE>` を都度指定）
- **`python/uv.lock`**: `[options].exclude-newer` スタンプを削除（**パッケージ版は据え置き**。`uv lock --check` 通過 → CIの `uv sync --frozen` に影響なし）
- **`.github/dependabot.yml`**: pip cooldown が供給網保護の唯一の番人である旨にコメント更新

## 効果

- **日付起因のPRは今後ゼロ**。依存更新は従来通り Dependabot PR（7日cooldown済み）で流れます。
- pip 26.1.2（PYSEC-2026-196修正・#365で導入）は維持。pip-audit クリーン。

## 検証

- `python/uv.lock` の差分は `[options]` 削除の3行のみ／`requirements.txt` 変更なし
- pytest 34 passed・pip-audit「No known vulnerabilities found」

> 補足: 手動 `uv lock`（再解決）を実行した場合のみ床が無く最新を引きます（レアケース・許容済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 43fa9af chore(deps): drop uv exclude-newer, rely on Dependabot 7-day cooldown

## 📁 Files Changed

**Total files changed: 3**

- ⚙️ **Configuration**: 2 files
- 📄 **Other**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/dependabot.yml`
- `python/uv.lock`

#### 📄 Other Files

- `python/pyproject.toml`

</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*