### PR TITLE
fix(ai): マイティーに表Jを被せる挙動 + 切り札リード時のSame2誤判定を修正

### DIFF
--- a/src/lib/ai/strategicCardEvaluator.ts
+++ b/src/lib/ai/strategicCardEvaluator.ts
@@ -38,7 +38,7 @@ import {
   getCardStrengthSafe,
   getLowestWinningCard,
   getWeakestCard,
-  getWeakestNonFaceCard,
+  getWeakestCardPreservingSame2,
   isFaceCard,
 } from './strategies/helpers'
 import { evaluateNapoleonCooperation } from './strategies/napoleonCooperation'
@@ -709,12 +709,16 @@ function selectFollowingCard(
     let weakest: Card
 
     if (player.isNapoleon || player.isAdjutant) {
-      // ナポレオンチーム：通常の最弱カード
-      weakest = getWeakestCard(playableCards, gameState)
+      // ナポレオンチーム：通常の最弱カード（セイム2用の2は温存）
+      weakest = getWeakestCardPreservingSame2(playableCards, gameState)
     } else {
-      // 連合軍：非絵札を優先（絵札を取られないようにする）
-      const weakestNonFace = getWeakestNonFaceCard(playableCards, gameState)
-      weakest = weakestNonFace || getWeakestCard(playableCards, gameState)
+      // 連合軍：非絵札を優先（絵札を取られないようにする）。捨てる際も
+      // セイム2用の2は温存し、他の弱い非絵札があればそちらを先に捨てる。
+      const nonFaceCards = playableCards.filter((card) => !isFaceCard(card))
+      weakest =
+        nonFaceCards.length > 0
+          ? getWeakestCardPreservingSame2(nonFaceCards, gameState)
+          : getWeakestCard(playableCards, gameState)
     }
 
     return weakest

--- a/src/lib/ai/strategies/adjutantTactics.ts
+++ b/src/lib/ai/strategies/adjutantTactics.ts
@@ -161,8 +161,17 @@ export function evaluateAdjutantTactics(
   // ナポレオンに渡すべき絵札を選択
   let faceCardToPass: Card | null = null
   if (shouldPassFaceCard) {
+    // マイティーだけでなく表J・裏Jも除外する。これらは「弱い絵札」ではなく
+    // 単独で別トリックを取れる最強級カードなので、マイティーが既に勝っている
+    // トリックに被せて捨ててはいけない（連合軍側の getFaceCardToPassToAlliance
+    // と同じ除外条件に揃える）。
+    const trumpSuit = (gameState.trumpSuit as Suit) || 'spades'
     const faceCards = playableCards.filter(
-      (card) => isFaceCard(card) && !checkIsMighty(card)
+      (card) =>
+        isFaceCard(card) &&
+        !checkIsMighty(card) &&
+        !checkIsTrumpJack(card, trumpSuit) &&
+        !checkIsCounterJack(card, trumpSuit)
     )
 
     if (faceCards.length > 0) {

--- a/src/lib/ai/strategies/helpers.ts
+++ b/src/lib/ai/strategies/helpers.ts
@@ -96,6 +96,36 @@ export function getWeakestNonFaceCard(
 }
 
 /**
+ * 捨て札として最弱カードを選ぶが、セイム2用の「2」を不用意に捨てない。
+ *
+ * 非切り札の2はセイム2が成立すれば単独でトリックを取れる切り札的な札なので、
+ * 勝てないトリックで捨てる場合でも、他に捨てられるカードがあり、かつ序盤〜中盤
+ * （セイム2を狙える時期）であれば2を温存して次に弱いカードを捨てる。
+ * 終盤（進行度0.7以上）は2が死に札になりやすいので通常どおり捨てる。
+ */
+export function getWeakestCardPreservingSame2(
+  cards: Card[],
+  gameState: GameState
+): Card {
+  const trumpSuit = (gameState.trumpSuit as Suit) || 'spades'
+  const sorted = [...cards].sort(
+    (a, b) =>
+      getCardStrengthSafe(a, gameState) - getCardStrengthSafe(b, gameState)
+  )
+
+  const weakest = sorted[0]
+  const isSame2Two = weakest.rank === '2' && weakest.suit !== trumpSuit
+  const gameProgress = calculateGameProgress(gameState)
+
+  // 序盤〜中盤で、2以外に捨てられる札がある場合のみ2を温存
+  if (isSame2Two && gameProgress < 0.7 && sorted.length > 1) {
+    return sorted[1]
+  }
+
+  return weakest
+}
+
+/**
  * ゲームの進行度を計算（0.0〜1.0）
  */
 export function calculateGameProgress(gameState: GameState): number {

--- a/src/lib/ai/strategies/specialCards.ts
+++ b/src/lib/ai/strategies/specialCards.ts
@@ -51,6 +51,11 @@ export function evaluateSame2Potential(
 
   // 現在のトリックで異なるスートが出ている場合、そのスートは4枚揃わない
   const leadingSuit = currentTrick.cards[0].card.suit
+
+  // 切り札リードのトリックではセイム2が成立しないので、2は通常の弱札扱い
+  // （セイム2ポテンシャルのボーナス/ペナルティを与えない）。
+  if (leadingSuit === trumpSuit) return 0
+
   const allSameSuit = currentTrick.cards.every(
     (pc) => pc.card.suit === leadingSuit
   )
@@ -194,11 +199,14 @@ export function evaluateSame2Breaker(card: Card, gameState: GameState): number {
       checkIsCounterJack(trickCard.card, trumpSuit)
   )
 
-  // セイム2の可能性があるトリックでMighty/Jackを出すとセイム2を台無しにする
+  // セイム2の可能性があるトリックでMighty/Jackを出すとセイム2を台無しにする。
+  // ただし切り札リード時はセイム2が成立しないので、ペナルティを与えない
+  // （切り札リードで Mighty / 表J を出すのを過剰に抑制しないため）。
   if (
     allSameSuit &&
     !alreadyHasSame2Breaker &&
-    currentTrick.cards.length >= 2
+    currentTrick.cards.length >= 2 &&
+    leadingSuit !== trumpSuit
   ) {
     // ゲーム進行度を取得
     const gameProgress = calculateGameProgress(gameState)
@@ -349,8 +357,14 @@ export function evaluateSpecialCardStrategy(
   )
 
   // セイム2リスク: 全て同じスートで特殊カードがまだ出ていない場合
+  // 切り札リード時はセイム2が成立しない（napoleonCardRules.checkSame2Conditions:
+  // leadingSuit === trumpSuit は無効）ため、リスク扱いしない。これを怠ると
+  // 切り札リードのトリックで Mighty / 表J の使用が誤ってブロックされる。
   const hasSame2Risk =
-    allSameSuit && !alreadyHasSpecialCard && currentTrick.cards.length >= 2
+    allSameSuit &&
+    !alreadyHasSpecialCard &&
+    currentTrick.cards.length >= 2 &&
+    leadingSuit !== trumpSuit
 
   // Mighty使用判断
   let shouldUseMighty = false

--- a/tests/lib/ai/strategies/same2AndAdjutant.test.ts
+++ b/tests/lib/ai/strategies/same2AndAdjutant.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Regression tests for:
+ *  - Fix A: Adjutant must not "pass" the Mighty/Trump-J/Counter-J as a weak face
+ *    card onto a trick Napoleon already wins (no covering Mighty with trump-J).
+ *  - Fix B: Same2 risk/breaker logic must be disabled on trump-led tricks
+ *    (Same2 is invalid when the leading suit is the trump suit).
+ *  - Fix C: When forced to discard, the AI preserves a non-trump "2" (kept for a
+ *    future Same2) instead of throwing it away early.
+ */
+
+import { evaluateAdjutantTactics } from '@/lib/ai/strategies/adjutantTactics'
+import {
+  getWeakestCardPreservingSame2,
+  isFaceCard,
+} from '@/lib/ai/strategies/helpers'
+import {
+  evaluateSame2Breaker,
+  evaluateSpecialCardStrategy,
+} from '@/lib/ai/strategies/specialCards'
+import type { WinningRequirements } from '@/lib/ai/strategies/types'
+import { GAME_PHASES } from '@/lib/constants'
+import { isCounterJack, isMighty, isTrumpJack } from '@/lib/napoleonCardRules'
+import type { Card, GameState, Player, Suit, Trick } from '@/types/game'
+
+type Rank = Card['rank']
+
+const card = (id: string, suit: Suit, rank: Rank, value = 0): Card => ({
+  id,
+  suit,
+  rank,
+  value,
+})
+
+const player = (id: string, opts: Partial<Player> = {}): Player => ({
+  id,
+  name: id,
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  isAI: true,
+  position: 1,
+  ...opts,
+})
+
+const trick = (cards: Array<{ card: Card; playerId: string }>): Trick => ({
+  id: 'current-trick',
+  cards: cards.map((c, i) => ({ ...c, order: i })),
+  leadingSuit: cards[0]?.card.suit,
+  completed: false,
+})
+
+const baseGameState = (over: Partial<GameState> = {}): GameState => ({
+  id: 'test-game',
+  players: [],
+  phase: GAME_PHASES.PLAYING,
+  currentPlayerIndex: 0,
+  hiddenCards: [],
+  trumpSuit: 'spades',
+  currentTrick: { id: 'current-trick', cards: [], completed: false },
+  tricks: [],
+  passedPlayers: [],
+  declarationTurn: 0,
+  needsRedeal: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...over,
+})
+
+const requirements: WinningRequirements = {
+  napoleonTeamFaceCards: 0,
+  allianceTeamFaceCards: 0,
+  remainingFaceCards: 20,
+  remainingTricks: 8,
+  napoleonNeedsToWin: 4,
+  allianceNeedsToBlock: 4,
+  napoleonCanAffordToLose: 0,
+  isNapoleonAhead: false,
+  isAllianceAhead: false,
+  isCriticalPhase: false,
+}
+
+// Trump = spades throughout (切り札スペード).
+const MIGHTY = card('mighty', 'spades', 'A', 14) // スペードA
+const TRUMP_JACK = card('trumpJ', 'spades', 'J', 11) // 表J（スペードJ）
+const COUNTER_JACK = card('counterJ', 'clubs', 'J', 11) // 裏J（クラブJ）
+
+describe('napoleonCardRules sanity (fixtures)', () => {
+  test('special card identification under spades trump', () => {
+    expect(isMighty(MIGHTY)).toBe(true)
+    expect(isTrumpJack(TRUMP_JACK, 'spades')).toBe(true)
+    expect(isCounterJack(COUNTER_JACK, 'spades')).toBe(true)
+  })
+})
+
+describe('Fix A: adjutant does not cover Mighty with the trump Jack', () => {
+  test('trump-J is NOT chosen as the face card to pass to a winning Napoleon', () => {
+    const napoleon = player('nap', { isNapoleon: true })
+    const adjutant = player('adj', { isAdjutant: true })
+    const ally = player('ally')
+
+    // Trick: ally leads a spade, Napoleon plays Mighty (now winning), ally follows.
+    const currentTrick = trick([
+      { card: card('lead', 'spades', 'K', 13), playerId: ally.id },
+      { card: MIGHTY, playerId: napoleon.id },
+      { card: card('a2', 'spades', 'Q', 12), playerId: 'ally2' },
+    ])
+
+    const gameState = baseGameState({
+      players: [napoleon, adjutant, ally, player('ally2')],
+      currentTrick,
+      leadingSuit: 'spades',
+    })
+
+    // Adjutant must follow spades; its only non-Mighty face option is the trump J.
+    const playable = [TRUMP_JACK, card('low', 'spades', '4', 4)]
+
+    const tactics = evaluateAdjutantTactics(
+      playable,
+      currentTrick,
+      gameState,
+      requirements
+    )
+
+    expect(tactics.shouldPassFaceCard).toBe(true)
+    // The trump Jack must never be passed (it would be wasted on Napoleon's
+    // already-winning Mighty trick).
+    expect(tactics.faceCardToPass).toBeNull()
+  })
+
+  test('a regular spade face card is still passed when available', () => {
+    const napoleon = player('nap', { isNapoleon: true })
+    const adjutant = player('adj', { isAdjutant: true })
+
+    const currentTrick = trick([
+      { card: card('lead', 'spades', '9', 9), playerId: 'ally' },
+      { card: MIGHTY, playerId: napoleon.id },
+      { card: card('a2', 'spades', '8', 8), playerId: 'ally2' },
+    ])
+    const gameState = baseGameState({
+      players: [napoleon, adjutant, player('ally'), player('ally2')],
+      currentTrick,
+      leadingSuit: 'spades',
+    })
+
+    const regularFace = card('king', 'spades', 'K', 13)
+    const playable = [TRUMP_JACK, regularFace, card('low', 'spades', '3', 3)]
+
+    const tactics = evaluateAdjutantTactics(
+      playable,
+      currentTrick,
+      gameState,
+      requirements
+    )
+
+    expect(tactics.faceCardToPass).not.toBeNull()
+    expect(isFaceCard(tactics.faceCardToPass as Card)).toBe(true)
+    expect(isTrumpJack(tactics.faceCardToPass as Card, 'spades')).toBe(false)
+    expect(isMighty(tactics.faceCardToPass as Card)).toBe(false)
+    expect(tactics.faceCardToPass?.id).toBe(regularFace.id)
+  })
+})
+
+describe('Fix B: Same2 logic is disabled on trump-led tricks', () => {
+  const napoleon = player('nap', { isNapoleon: true })
+
+  test('hasSame2Risk is false when the lead suit is the trump suit', () => {
+    // All spades (trump) led — Same2 cannot happen, so it must not block specials.
+    const currentTrick = trick([
+      { card: card('s1', 'spades', '9', 9), playerId: 'p1' },
+      { card: card('s2', 'spades', '8', 8), playerId: 'p2' },
+    ])
+    const gameState = baseGameState({
+      players: [napoleon, player('p1'), player('p2'), player('p3')],
+      currentTrick,
+      leadingSuit: 'spades',
+    })
+
+    const strategy = evaluateSpecialCardStrategy(
+      napoleon,
+      [MIGHTY, card('low', 'spades', '3', 3)],
+      currentTrick,
+      gameState,
+      () => ({ napoleonNeedsToWin: 1 })
+    )
+
+    expect(strategy.hasSame2Risk).toBe(false)
+  })
+
+  test('hasSame2Risk is still true on a non-trump all-same-suit lead', () => {
+    const currentTrick = trick([
+      { card: card('h1', 'hearts', '9', 9), playerId: 'p1' },
+      { card: card('h2', 'hearts', '8', 8), playerId: 'p2' },
+    ])
+    const gameState = baseGameState({
+      players: [napoleon, player('p1'), player('p2'), player('p3')],
+      currentTrick,
+      leadingSuit: 'hearts',
+    })
+
+    const strategy = evaluateSpecialCardStrategy(
+      napoleon,
+      [MIGHTY, card('low', 'hearts', '3', 3)],
+      currentTrick,
+      gameState,
+      () => ({ napoleonNeedsToWin: 1 })
+    )
+
+    expect(strategy.hasSame2Risk).toBe(true)
+  })
+
+  test('evaluateSame2Breaker gives no penalty to Mighty on a trump-led trick', () => {
+    const currentTrick = trick([
+      { card: card('s1', 'spades', '9', 9), playerId: 'p1' },
+      { card: card('s2', 'spades', '8', 8), playerId: 'p2' },
+    ])
+    const gameState = baseGameState({ currentTrick, leadingSuit: 'spades' })
+
+    expect(evaluateSame2Breaker(MIGHTY, gameState)).toBe(0)
+  })
+
+  test('evaluateSame2Breaker still penalizes Mighty on a non-trump same-suit trick', () => {
+    const currentTrick = trick([
+      { card: card('h1', 'hearts', '9', 9), playerId: 'p1' },
+      { card: card('h2', 'hearts', '8', 8), playerId: 'p2' },
+    ])
+    const gameState = baseGameState({ currentTrick, leadingSuit: 'hearts' })
+
+    expect(evaluateSame2Breaker(MIGHTY, gameState)).toBeLessThan(0)
+  })
+})
+
+describe('Fix C: preserve the non-trump "2" when discarding', () => {
+  test('early game: discards another low card and keeps the non-trump 2', () => {
+    const gameState = baseGameState({ tricks: [] }) // progress 0
+    const two = card('d2', 'diamonds', '2', 2)
+    const three = card('d3', 'diamonds', '3', 3)
+
+    const chosen = getWeakestCardPreservingSame2([two, three], gameState)
+    expect(chosen.id).toBe(three.id) // keeps the 2
+  })
+
+  test('discards the 2 when it is the only option', () => {
+    const gameState = baseGameState({ tricks: [] })
+    const two = card('d2', 'diamonds', '2', 2)
+
+    expect(getWeakestCardPreservingSame2([two], gameState).id).toBe(two.id)
+  })
+
+  test('late game: no longer preserves the 2 (dead card)', () => {
+    // 9 completed tricks => progress 0.75 (>= 0.7)
+    const gameState = baseGameState({
+      tricks: Array.from({ length: 9 }, (_, i) => ({
+        id: `t${i}`,
+        cards: [],
+        completed: true,
+      })),
+    })
+    const two = card('d2', 'diamonds', '2', 2)
+    const three = card('d3', 'diamonds', '3', 3)
+
+    expect(getWeakestCardPreservingSame2([two, three], gameState).id).toBe(
+      two.id
+    )
+  })
+
+  test('the trump "2" is not specially preserved (it cannot make Same2)', () => {
+    const gameState = baseGameState({ tricks: [] }) // trump = spades
+    const trumpTwo = card('s2', 'spades', '2', 2)
+    const trumpThree = card('s3', 'spades', '3', 3)
+
+    // Weakest spade is the 2; since it cannot form Same2, it is discarded normally.
+    expect(
+      getWeakestCardPreservingSame2([trumpTwo, trumpThree], gameState).id
+    ).toBe(trumpTwo.id)
+  })
+})


### PR DESCRIPTION
## 概要

「切り札スペードでマイティー(A♠)と表J(J♠)を同じトリックに被せてしまう」問題の原因を特定し、関連する3点を修正しました。

## 修正内容

### Fix A: 副官が表J/裏Jをマイティーに被せない（主因）
`evaluateAdjutantTactics` の「勝っているナポレオンに弱い絵札を渡す」処理で、除外していたのが **マイティーのみ**で表J・裏Jを除外していませんでした。そのため副官が切り札スペードをフォローする際、出せる非マイティー絵札が表J(J♠)だけだと、**マイティーが既に勝っているトリックに表Jを捨てて**しまい、最強級2枚を1トリックで無駄打ちしていました。
→ 連合軍側の `getFaceCardToPassToAlliance` と同じく **表J・裏Jも除外**するよう修正。

### Fix B: 切り札リード時のSame2誤判定を修正（補助要因）
Same2は**リードスートが切り札のトリックでは成立しません**（`napoleonCardRules.checkSame2Conditions`）。しかしAI側の `hasSame2Risk` / `evaluateSame2Breaker` / `evaluateSame2Potential` はこれを考慮しておらず、スペードリードのトリックで誤って「Same2リスクあり」と判定 → **Mighty/表Jの使用を抑制**していました（これがFix Aの素朴な絵札パスへのフォールバックを誘発）。
→ 3関数すべてに `leadingSuit !== trumpSuit` ガードを追加。

### Fix C: Same2用の「2」を早期に捨てない（ご要望の追加改善）
勝てないトリックでカードを捨てる際、AIは**文字通り最弱のカード**を出すため、Same2用に温存すべき**非切り札の2**を早々に捨てていました（Jが出ていても捨てる）。
→ 新ヘルパー `getWeakestCardPreservingSame2` を追加。序盤〜中盤で他に捨て札があれば非切り札の2を温存し、終盤（進行度0.7以上）は死に札になるため通常どおり捨てます。

## テスト
- 新規 `tests/lib/ai/strategies/same2AndAdjutant.test.ts`（11テスト、3 Fix を網羅）
- 既存のAIテスト **364件**＋カードルールテストも全green（回帰なし）

## 補足
Fix C はゲーム進行度ベースのヒューリスティック（カードカウンティングまでは見ていない）です。必要なら「そのスートが場にまだ残っているか」を加味した精緻化も可能です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 1f1e95c fix(ai): stop covering Mighty with the trump Jack; fix Same2 on trump leads

## 📁 Files Changed

**Total files changed: 5**

- 🔧 **Source Code**: 4 files
- 🧪 **Tests**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/lib/ai/strategies/same2AndAdjutant.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/lib/ai/strategicCardEvaluator.ts`
- `src/lib/ai/strategies/adjutantTactics.ts`
- `src/lib/ai/strategies/helpers.ts`
- `src/lib/ai/strategies/specialCards.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/ai-mighty-trumpj-same2
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*