### PR TITLE
style: reformat RECENT_IMPROVEMENTS.md for prettier 3.9.4

### DIFF
--- a/docs/game-logic/RECENT_IMPROVEMENTS.md
+++ b/docs/game-logic/RECENT_IMPROVEMENTS.md
@@ -1261,19 +1261,7 @@ const isAdjutantRevealed =
 // Before: game.ts had hardcoded types
 export type Suit = 'hearts' | 'diamonds' | 'clubs' | 'spades';
 export type Rank =
-  | 'A'
-  | '2'
-  | '3'
-  | '4'
-  | '5'
-  | '6'
-  | '7'
-  | '8'
-  | '9'
-  | '10'
-  | 'J'
-  | 'Q'
-  | 'K';
+  'A' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '10' | 'J' | 'Q' | 'K';
 
 // After: game.ts imports from constants
 import type {


### PR DESCRIPTION
## 概要

リリースPR (#325) の `build-and-test` が `format:other:check`（Prettier）で失敗していた問題を修正します。

## 原因

先日マージした dev-dependencies 更新で **Prettier が 3.8.3 → 3.9.4** に上がりました。3.9.4 は `docs/game-logic/RECENT_IMPROVEMENTS.md` 内の埋め込みTypeScript union型の整形ルールが変わり、1行に収めるようになりました。CIは `frozen-lockfile` で 3.9.4 を使うため整形崩れとして検出され、リリースPRが赤くなっていました。

## 変更

- `prettier@3.9.4`（lockfileと同一）で `RECENT_IMPROVEMENTS.md` を再整形
- ドキュメント内のコード例のみの変更で、アプリ挙動・ロジックへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- c549eeb style: reformat RECENT_IMPROVEMENTS.md for prettier 3.9.4

## 📁 Files Changed

**Total files changed: 1**

- 📚 **Documentation**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation

- `docs/game-logic/RECENT_IMPROVEMENTS.md`

#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 📝 **Documentation** - Documentation updates

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*