### PR TITLE
refactor(terraform): migrate deprecated vulnerability_alerts to dedicated resource

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -21,12 +21,16 @@ resource "github_repository" "napoleon_game" {
   allow_auto_merge       = false  # 自動マージ無効（手動マージのみ）
   delete_branch_on_merge = true   # マージ後ブランチ自動削除
 
-  # Security
-  vulnerability_alerts = true
-
   # Archive settings
   archived           = false
   archive_on_destroy = false
+}
+
+# Security: Dependabot vulnerability alerts
+# Replaces the deprecated `vulnerability_alerts` field on github_repository.
+resource "github_repository_vulnerability_alerts" "napoleon_game" {
+  repository = github_repository.napoleon_game.name
+  enabled    = true
 }
 
 # Repository Ruleset: develop (development integration)


### PR DESCRIPTION
## 概要

`integrations/github` v6 プロバイダで非推奨となった `github_repository.vulnerability_alerts` フィールドを、推奨の専用リソース `github_repository_vulnerability_alerts` に移行します。`terraform validate` の非推奨警告を解消します。

## 変更

- `github_repository.napoleon_game` から `vulnerability_alerts = true` を削除
- `github_repository_vulnerability_alerts.napoleon_game`（`enabled = true`）を追加

## 安全性（state影響）

- `vulnerability_alerts` は **computed** 属性のため、`github_repository` から外しても Terraform は変更を試みません（管理対象から外れるだけ / perpetual diff なし・誤って無効化しない）
- 新リソースは既に有効な設定を冪等に再有効化するだけで、実挙動の変化なし
- 確認: `terraform validate` → **警告ゼロ**（"Success! The configuration is valid."）

## 注意

現在 Terraform Cloud の run は `github_token`(PAT) 失効により失敗中です。本PRの apply が実際に反映されるのは PAT 更新後になります（本変更自体は正しく、PATを直せば正常に adopt されます）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 1eb5d9c refactor(terraform): migrate vulnerability_alerts to dedicated resource

## 📁 Files Changed

**Total files changed: 1**

- 📄 **Other**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files

- `terraform/github.tf`

</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*