### PR TITLE
revert(terraform): restore vulnerability_alerts field (provider 6.11.1 compat)

### DIFF
--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -21,16 +21,12 @@ resource "github_repository" "napoleon_game" {
   allow_auto_merge       = false  # 自動マージ無効（手動マージのみ）
   delete_branch_on_merge = true   # マージ後ブランチ自動削除
 
+  # Security
+  vulnerability_alerts = true
+
   # Archive settings
   archived           = false
   archive_on_destroy = false
-}
-
-# Security: Dependabot vulnerability alerts
-# Replaces the deprecated `vulnerability_alerts` field on github_repository.
-resource "github_repository_vulnerability_alerts" "napoleon_game" {
-  repository = github_repository.napoleon_game.name
-  enabled    = true
 }
 
 # Repository Ruleset: develop (development integration)


### PR DESCRIPTION
## 概要

#444 を差し戻します。Terraform Cloud の plan が以下のエラーで失敗したためです:

```
Error: Invalid resource type
The provider integrations/github does not support resource type
"github_repository_vulnerability_alerts".
```

## 原因

`github_repository_vulnerability_alerts` リソースは `integrations/github` の **6.11.1 より後**の版で追加されたものですが、Terraform Cloud は `.terraform.lock.hcl` で **6.11.1 に固定**しているため未対応でした。6.11.1 ではインラインの `vulnerability_alerts` フィールドは非推奨ですらなく正常動作します（#444 で見た非推奨警告は、ローカルが lock を無視して新しい版を引いていたためでした）。

## 変更

- `github_repository_vulnerability_alerts` リソースを削除し、`github_repository.napoleon_game` に `vulnerability_alerts = true` を復元（#444 前の状態に一致）

## 確認

- 固定版 **6.11.1** で `terraform validate` → **valid・警告なし**
- #444 前のコミット(585dbf6)と差分ゼロ

## 補足

今回の一連の調査で **GitHub PAT の更新は成功**しています（TFC run が認証を通過して plan 段階まで到達）。本PRをマージ後、TFC で新しい run を実行すれば Terraform チェックが緑になる見込みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- f6b2253 revert(terraform): restore vulnerability_alerts field on github_repository

## 📁 Files Changed

**Total files changed: 1**

- 📄 **Other**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files

- `terraform/github.tf`

</details>

## 🏷️ Change Type


## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*