### PR TITLE
fix(game): 副官の正体が副官指定カード公開前に漏れる問題を修正

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -16,7 +16,10 @@ import { GAME_PHASES } from '@/lib/constants'
 import { getNextDeclarationPlayer } from '@/lib/napoleonRules'
 import { calculateGameResult, getPlayerFaceCardCount } from '@/lib/scoring'
 import type { Card as CardType, NapoleonDeclaration } from '@/types/game'
-import { checkAdjutantRevealed } from '@/utils/gameUtils'
+import {
+  checkAdjutantRevealed,
+  isAdjutantIdentityPublic,
+} from '@/utils/gameUtils'
 
 // 動的インポート - 初期バンドルサイズを削減
 const GameBoard = dynamic(
@@ -311,6 +314,8 @@ function GamePageContent() {
             trick={gameState.lastCompletedTrick}
             players={gameState.players}
             onContinue={() => actions.closeTrickResult()}
+            isAdjutantRevealed={isAdjutantIdentityPublic(gameState)}
+            currentPlayerId={currentPlayerId}
           />
         </div>
       )
@@ -511,6 +516,8 @@ function GamePageContent() {
             trick={gameState.lastCompletedTrick}
             players={gameState.players}
             onContinue={() => actions.closeTrickResult()}
+            isAdjutantRevealed={isAdjutantIdentityPublic(gameState)}
+            currentPlayerId={currentPlayerId}
           />
         )}
       </div>

--- a/src/components/game/TrickResult.tsx
+++ b/src/components/game/TrickResult.tsx
@@ -13,9 +13,19 @@ interface TrickResultProps {
     isAdjutant?: boolean
   }>
   onContinue: () => void
+  /** 副官指定カードが場に出て正体が公開済みかどうか */
+  isAdjutantRevealed?: boolean
+  /** 閲覧者のプレイヤーID（自分の正体は常に見える） */
+  currentPlayerId?: string | null
 }
 
-export function TrickResult({ trick, players, onContinue }: TrickResultProps) {
+export function TrickResult({
+  trick,
+  players,
+  onContinue,
+  isAdjutantRevealed = false,
+  currentPlayerId,
+}: TrickResultProps) {
   const [isClosing, setIsClosing] = useState(false)
 
   if (!trick.completed || !trick.winnerPlayerId) {
@@ -24,6 +34,11 @@ export function TrickResult({ trick, players, onContinue }: TrickResultProps) {
 
   const winner = players.find((p) => p.id === trick.winnerPlayerId)
   const faceCardsInPhase = trick.cards.filter((pc) => isFaceCard(pc.card))
+
+  // 副官の正体は公開されるまで隠す（自分自身の正体は常に表示）
+  const showWinnerAdjutantBadge =
+    Boolean(winner?.isAdjutant) &&
+    (isAdjutantRevealed || winner?.id === currentPlayerId)
 
   const getCardDisplay = (playedCard: PlayedCard) => {
     const card = playedCard.card
@@ -56,7 +71,7 @@ export function TrickResult({ trick, players, onContinue }: TrickResultProps) {
               <div className="text-sm md:text-base font-bold text-blue-700 truncate">
                 {winner?.name}
                 {winner?.isNapoleon && ' 👑'}
-                {winner?.isAdjutant && ' ⚔️'}
+                {showWinnerAdjutantBadge && ' ⚔️'}
               </div>
             </div>
             <div className="flex-shrink-0 ml-2">

--- a/src/lib/game/maskGameState.ts
+++ b/src/lib/game/maskGameState.ts
@@ -6,12 +6,17 @@
  * 枚数は保持するため、`hand.length` に依存する UI（OpponentHand /
  * GameBoard / scoring の cardsInHand）はそのまま動作する。
  *
+ * さらに副官の正体（`isAdjutant`）も、副官指定カードが場に出るまでは
+ * 閲覧者本人以外について false へ落とす。UI 側でガードしても
+ * レスポンスに残っていれば DevTools から丸見えになるため。
+ *
  * AI の思考はすべてサーバーサイド（processAITurn / processAIPlayingPhase）で
  * 行われ、DB から読み直した未マスクの状態を使うため、マスキングの影響を受けない。
  */
 
 import { MASKED_CARD } from '@/lib/constants'
 import type { Card, GameState } from '@/types/game'
+import { isAdjutantIdentityPublic } from '@/utils/gameUtils'
 
 function createMaskedCard(ownerKey: string, index: number): Card {
   return {
@@ -27,7 +32,7 @@ function maskCards(cards: Card[], ownerKey: string): Card[] {
 }
 
 /**
- * 閲覧者以外の手札・伏せ札をマスクしたゲーム状態を返す
+ * 閲覧者以外の手札・伏せ札・副官の正体をマスクしたゲーム状態を返す
  * @param gameState 未マスクのゲーム状態
  * @param viewerPlayerId 閲覧者（認証済みプレイヤー）のID
  */
@@ -35,12 +40,19 @@ export function maskGameStateForPlayer(
   gameState: GameState,
   viewerPlayerId: string
 ): GameState {
+  const adjutantIsPublic = isAdjutantIdentityPublic(gameState)
+
   return {
     ...gameState,
     players: gameState.players.map((player) =>
       player.id === viewerPlayerId
         ? player
-        : { ...player, hand: maskCards(player.hand, player.id) }
+        : {
+            ...player,
+            hand: maskCards(player.hand, player.id),
+            // 副官本人以外には、公開されるまで副官フラグを渡さない
+            isAdjutant: adjutantIsPublic ? player.isAdjutant : false,
+          }
     ),
     hiddenCards: maskCards(
       gameState.hiddenCards,

--- a/src/utils/gameUtils.ts
+++ b/src/utils/gameUtils.ts
@@ -1,3 +1,4 @@
+import { GAME_PHASES } from '@/lib/constants'
 import type { GameState } from '@/types/game'
 
 /**
@@ -16,5 +17,22 @@ export function checkAdjutantRevealed(gameState: GameState): boolean {
       trick.cards.some((pc) => pc.revealsAdjutant)
     ) ||
     gameState.currentTrick.cards.some((pc) => pc.revealsAdjutant)
+  )
+}
+
+/**
+ * 副官の正体を全プレイヤーへ公開してよいか判定する
+ *
+ * - 副官指定カードが場に出た時点で公開（checkAdjutantRevealed）
+ * - ゲーム終了後は結果画面で全役職を公開する。早期終了（isGameDecided）で
+ *   副官指定カードが出ないまま終わる場合があり、勝敗・スコア表示にも必要
+ *
+ * ナポレオン本人にも事前公開しない。ナポレオンが指定するのは「カード」であって
+ * プレイヤーではなく（setAdjutant / AdjutantSelector）、誰がそのカードを
+ * 持っているかは副官指定カードが場に出るまで分からないため。
+ */
+export function isAdjutantIdentityPublic(gameState: GameState): boolean {
+  return (
+    gameState.phase === GAME_PHASES.FINISHED || checkAdjutantRevealed(gameState)
   )
 }

--- a/tests/app/actions/aiStrategyActions.test.ts
+++ b/tests/app/actions/aiStrategyActions.test.ts
@@ -211,6 +211,38 @@ describe('AI Strategy Actions', () => {
       expect(saveGameStateAction).toHaveBeenCalledWith(updatedGameState, 'p1')
     })
 
+    // COM が副官のとき、AI と DB 保存には未マスクの isAdjutant が渡り、
+    // クライアントへのレスポンスだけが伏せられることを保証する
+    it('gives the AI the unmasked adjutant flag while masking the response', async () => {
+      const aiAdjutant = { ...createPlayer('ai-1', true), isAdjutant: true }
+      const gameState = createGameState([aiAdjutant, createPlayer('p1')])
+      const updatedGameState = { ...gameState }
+
+      ;(requireGameState as jest.Mock).mockResolvedValue(gameState)
+      ;(processAITurn as jest.Mock).mockResolvedValue(updatedGameState)
+      ;(saveGameStateAction as jest.Mock).mockResolvedValue({ success: true })
+
+      const result = await processAITurnAction('game-1', 'p1')
+
+      // AI 側は未マスク
+      const stateGivenToAI = (processAITurn as jest.Mock).mock
+        .calls[0][0] as GameState
+      expect(
+        stateGivenToAI.players.find((p) => p.id === 'ai-1')?.isAdjutant
+      ).toBe(true)
+
+      const savedState = (saveGameStateAction as jest.Mock).mock
+        .calls[0][0] as GameState
+      expect(savedState.players.find((p) => p.id === 'ai-1')?.isAdjutant).toBe(
+        true
+      )
+
+      // クライアントへのレスポンスは伏せられている
+      expect(
+        result.data?.players.find((p) => p.id === 'ai-1')?.isAdjutant
+      ).toBe(false)
+    })
+
     it('should process AI turn in NAPOLEON phase', async () => {
       const aiPlayer = createPlayer('ai-1', true)
       const gameState = {

--- a/tests/components/game/TrickResult.test.tsx
+++ b/tests/components/game/TrickResult.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '@testing-library/react'
+import { TrickResult } from '@/components/game/TrickResult'
+import type { Card, Trick } from '@/types/game'
+
+const ADJUTANT_BADGE = '⚔️'
+const NAPOLEON_BADGE = '👑'
+const WINNER_LABEL = '🏆 Winner'
+
+const createCard = (id: string): Card => ({
+  id,
+  suit: 'hearts',
+  rank: 'K',
+  value: 13,
+})
+
+const players = [
+  { id: 'napoleon', name: 'Napoleon Player', isNapoleon: true },
+  { id: 'adjutant', name: 'Adjutant Player', isAdjutant: true },
+]
+
+const trick: Trick = {
+  id: 'trick-1',
+  cards: [
+    { card: createCard('c1'), playerId: 'napoleon', order: 0 },
+    { card: createCard('c2'), playerId: 'adjutant', order: 1 },
+  ],
+  completed: true,
+  winnerPlayerId: 'adjutant',
+}
+
+/** 「🏆 Winner」ラベルの隣に描画される勝者名ブロックのテキストを取得 */
+const getWinnerText = (): string =>
+  screen.getByText(WINNER_LABEL).nextElementSibling?.textContent ?? ''
+
+describe('TrickResult adjutant badge', () => {
+  it('hides the adjutant badge before the adjutant is revealed', () => {
+    render(
+      <TrickResult
+        trick={trick}
+        players={players}
+        onContinue={jest.fn()}
+        isAdjutantRevealed={false}
+        currentPlayerId="napoleon"
+      />
+    )
+
+    expect(getWinnerText()).toContain('Adjutant Player')
+    expect(getWinnerText()).not.toContain(ADJUTANT_BADGE)
+  })
+
+  it('hides the adjutant badge when the guard props are omitted', () => {
+    render(
+      <TrickResult trick={trick} players={players} onContinue={jest.fn()} />
+    )
+
+    expect(getWinnerText()).not.toContain(ADJUTANT_BADGE)
+  })
+
+  it('shows the adjutant badge after the adjutant is revealed', () => {
+    render(
+      <TrickResult
+        trick={trick}
+        players={players}
+        onContinue={jest.fn()}
+        isAdjutantRevealed={true}
+        currentPlayerId="napoleon"
+      />
+    )
+
+    expect(getWinnerText()).toContain(ADJUTANT_BADGE)
+  })
+
+  it('always shows the badge to the adjutant themselves', () => {
+    render(
+      <TrickResult
+        trick={trick}
+        players={players}
+        onContinue={jest.fn()}
+        isAdjutantRevealed={false}
+        currentPlayerId="adjutant"
+      />
+    )
+
+    expect(getWinnerText()).toContain(ADJUTANT_BADGE)
+  })
+
+  it('keeps the public Napoleon badge visible before the reveal', () => {
+    const napoleonWonTrick: Trick = { ...trick, winnerPlayerId: 'napoleon' }
+
+    render(
+      <TrickResult
+        trick={napoleonWonTrick}
+        players={players}
+        onContinue={jest.fn()}
+        isAdjutantRevealed={false}
+        currentPlayerId="adjutant"
+      />
+    )
+
+    expect(getWinnerText()).toContain(NAPOLEON_BADGE)
+  })
+})

--- a/tests/lib/game/maskGameState.test.ts
+++ b/tests/lib/game/maskGameState.test.ts
@@ -4,7 +4,7 @@
 
 import { GAME_PHASES, MASKED_CARD } from '@/lib/constants'
 import { maskGameStateForPlayer } from '@/lib/game/maskGameState'
-import type { Card, GameState, Player } from '@/types/game'
+import type { Card, GameState, PlayedCard, Player, Trick } from '@/types/game'
 
 const createCard = (id: string, rank: Card['rank']): Card => ({
   id,
@@ -12,6 +12,9 @@ const createCard = (id: string, rank: Card['rank']): Card => ({
   rank,
   value: 10,
 })
+
+/** 副官指定カード（ナポレオンが宣言時に指定した公開情報） */
+const adjutantDesignationCard = createCard('adjutant-card', 'A')
 
 const createPlayer = (id: string, hand: Card[]): Player => ({
   id,
@@ -23,7 +26,7 @@ const createPlayer = (id: string, hand: Card[]): Player => ({
   isAI: false,
 })
 
-const createGameState = (): GameState => ({
+const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
   id: 'test-game',
   players: [
     createPlayer('me', [createCard('c1', 'A'), createCard('c2', 'K')]),
@@ -41,6 +44,30 @@ const createGameState = (): GameState => ({
   needsRedeal: false,
   createdAt: new Date(),
   updatedAt: new Date(),
+  ...overrides,
+})
+
+/** 副官が 'other'、ナポレオンが 'me' の状態を作る */
+const createAdjutantGameState = (
+  overrides: Partial<GameState> = {}
+): GameState => {
+  const base = createGameState(overrides)
+  return {
+    ...base,
+    players: base.players.map((player) =>
+      player.id === 'other'
+        ? { ...player, isAdjutant: true }
+        : { ...player, isNapoleon: player.id === 'me' }
+    ),
+    napoleonCard: adjutantDesignationCard,
+  }
+}
+
+const createCompletedTrick = (cards: PlayedCard[]): Trick => ({
+  id: 'trick-played',
+  cards,
+  completed: true,
+  winnerPlayerId: cards[0]?.playerId,
 })
 
 describe('maskGameStateForPlayer', () => {
@@ -94,5 +121,117 @@ describe('maskGameStateForPlayer', () => {
         expect(card.id.startsWith(MASKED_CARD.ID_PREFIX)).toBe(true)
       }
     }
+  })
+})
+
+describe('maskGameStateForPlayer - adjutant identity', () => {
+  describe('before the adjutant designation card is played', () => {
+    it('hides another player isAdjutant flag', () => {
+      const masked = maskGameStateForPlayer(createAdjutantGameState(), 'me')
+      const other = masked.players.find((p) => p.id === 'other')
+
+      expect(other?.isAdjutant).toBe(false)
+    })
+
+    it('does not leak the adjutant flag anywhere in the payload', () => {
+      const masked = maskGameStateForPlayer(createAdjutantGameState(), 'me')
+
+      expect(JSON.stringify(masked)).not.toContain('"isAdjutant":true')
+    })
+
+    it('hides the adjutant from Napoleon as well', () => {
+      const state = createAdjutantGameState()
+      const napoleon = state.players.find((p) => p.isNapoleon)
+      const masked = maskGameStateForPlayer(state, napoleon?.id ?? '')
+
+      expect(masked.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
+        false
+      )
+    })
+
+    it('keeps the adjutant own flag visible to themselves', () => {
+      const masked = maskGameStateForPlayer(createAdjutantGameState(), 'other')
+      const me = masked.players.find((p) => p.id === 'other')
+
+      expect(me?.isAdjutant).toBe(true)
+    })
+
+    it('does not mutate the original (server side) state', () => {
+      const original = createAdjutantGameState()
+      maskGameStateForPlayer(original, 'me')
+
+      expect(original.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
+        true
+      )
+    })
+
+    it('keeps the public isNapoleon flag untouched', () => {
+      const masked = maskGameStateForPlayer(createAdjutantGameState(), 'other')
+
+      expect(masked.players.find((p) => p.id === 'me')?.isNapoleon).toBe(true)
+    })
+  })
+
+  describe('after the adjutant is revealed', () => {
+    it('exposes isAdjutant once the designation card is in a completed trick', () => {
+      const state = createAdjutantGameState({
+        tricks: [
+          createCompletedTrick([
+            { card: adjutantDesignationCard, playerId: 'other', order: 0 },
+          ]),
+        ],
+      })
+      const masked = maskGameStateForPlayer(state, 'me')
+
+      expect(masked.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
+        true
+      )
+    })
+
+    it('exposes isAdjutant when Napoleon played it from the hidden cards (revealsAdjutant)', () => {
+      const revealingCard: PlayedCard = {
+        card: adjutantDesignationCard,
+        playerId: 'me',
+        order: 0,
+        revealsAdjutant: true,
+      }
+      const state = createAdjutantGameState({
+        currentTrick: {
+          id: 'trick-1',
+          cards: [revealingCard],
+          completed: false,
+        },
+      })
+      const masked = maskGameStateForPlayer(state, 'me')
+
+      expect(masked.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
+        true
+      )
+    })
+
+    it('exposes isAdjutant when the game is finished', () => {
+      const state = createAdjutantGameState({ phase: GAME_PHASES.FINISHED })
+      const masked = maskGameStateForPlayer(state, 'me')
+
+      expect(masked.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
+        true
+      )
+    })
+
+    it('still masks other players hands after the reveal', () => {
+      const state = createAdjutantGameState({
+        tricks: [
+          createCompletedTrick([
+            { card: adjutantDesignationCard, playerId: 'other', order: 0 },
+          ]),
+        ],
+      })
+      const masked = maskGameStateForPlayer(state, 'me')
+      const other = masked.players.find((p) => p.id === 'other')
+
+      for (const card of other?.hand ?? []) {
+        expect(card.id.startsWith(MASKED_CARD.ID_PREFIX)).toBe(true)
+      }
+    })
   })
 })

--- a/tests/utils/gameUtils.test.ts
+++ b/tests/utils/gameUtils.test.ts
@@ -1,0 +1,77 @@
+import { GAME_PHASES } from '@/lib/constants'
+import type { Card, GameState, PlayedCard } from '@/types/game'
+import {
+  checkAdjutantRevealed,
+  isAdjutantIdentityPublic,
+} from '@/utils/gameUtils'
+
+const adjutantCard: Card = {
+  id: 'adjutant-card',
+  suit: 'hearts',
+  rank: 'A',
+  value: 14,
+}
+
+const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
+  id: 'test-game',
+  players: [],
+  phase: GAME_PHASES.PLAYING,
+  currentPlayerIndex: 0,
+  currentTrick: { id: 'trick-1', cards: [], completed: false },
+  tricks: [],
+  hiddenCards: [],
+  napoleonCard: adjutantCard,
+  passedPlayers: [],
+  declarationTurn: 0,
+  needsRedeal: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+})
+
+const playedAdjutantCard: PlayedCard = {
+  card: adjutantCard,
+  playerId: 'adjutant',
+  order: 0,
+}
+
+describe('isAdjutantIdentityPublic', () => {
+  it('is false while the designation card has not been played', () => {
+    expect(isAdjutantIdentityPublic(createGameState())).toBe(false)
+  })
+
+  it('is true once the designation card is in a completed trick', () => {
+    const state = createGameState({
+      tricks: [
+        {
+          id: 'trick-0',
+          cards: [playedAdjutantCard],
+          completed: true,
+          winnerPlayerId: 'adjutant',
+        },
+      ],
+    })
+
+    expect(checkAdjutantRevealed(state)).toBe(true)
+    expect(isAdjutantIdentityPublic(state)).toBe(true)
+  })
+
+  it('is true when a played card carries the revealsAdjutant flag', () => {
+    const state = createGameState({
+      currentTrick: {
+        id: 'trick-1',
+        cards: [{ ...playedAdjutantCard, revealsAdjutant: true }],
+        completed: false,
+      },
+    })
+
+    expect(isAdjutantIdentityPublic(state)).toBe(true)
+  })
+
+  it('is true when the game is finished even if the card was never played', () => {
+    const state = createGameState({ phase: GAME_PHASES.FINISHED })
+
+    expect(checkAdjutantRevealed(state)).toBe(false)
+    expect(isAdjutantIdentityPublic(state)).toBe(true)
+  })
+})


### PR DESCRIPTION
## 概要

実プレイで発見。**副官指定カードが場に出ていないのに、画面上で誰が副官か分かってしまう**状態でした。ナポレオンゲームでは副官の正体はカードが出るまで秘匿されるルールなので、ゲームが成立しません。

## 漏洩箇所

| 箇所 | 内容 |
| --- | --- |
| **サーバーレスポンス全般** | **本命**。`isAdjutant: true` が全 Server Action のレスポンスと Realtime 購読にそのまま乗っていた。UI でガードしても DevTools で見える |
| `src/components/game/TrickResult.tsx:59` | 副官が公開前にトリックを取ると、勝者名の横に ⚔️ が表示されていた |

先日修正した手札漏洩（F-3）とまったく同じ構造です。

## 修正

`src/utils/gameUtils.ts` に共通述語 `isAdjutantIdentityPublic(gameState)` を追加し、クライアントとサーバーで同一判定を使用します。

```
phase === FINISHED || checkAdjutantRevealed(gameState)
```

`maskGameStateForPlayer()` が、公開前は閲覧者以外の `isAdjutant` を `false` にマスクします。

### ナポレオンにも見せない

`setAdjutant()` (`gameLogic.ts:197-236`) はナポレオンが指定した**カード**を受け取り、`findAdjutant()` が**それを持っている人**を探して `isAdjutant` を立てます。`AdjutantSelector` もカードを選ぶ UI であってプレイヤーを選びません。指定カードが `hiddenCards` にあれば副官不在にもなり得ます（`napoleonRules.ts:255`）。**ナポレオン自身も誰が持っているか知らない設計**のため、ナポレオン特例は設けていません。

### FINISHED で公開する理由

`isGameDecided()` による早期終了で、副官指定カードが場に出ないままゲームが終わり得ます。公開しないと結果画面の役職表示と `calculateGameResult()` の勝者判定が壊れます。

### 変更しなかった箇所

`page.tsx:362` は `phase === FINISHED` の結果画面で、全役職が公開されるべき場所です（349-350 行の勝敗判定が `isAdjutant` を必要とします）。`isNapoleon` は宣言で名乗る公開情報のため対象外です。

## COM への影響なし

- AI 実行系は `requireGameState()`（**未マスク**）で状態を取得。`saveGameStateAction` にも未マスクを渡し、返り値だけマスク
- `src/components` / `hooks` / `contexts` / `app/game` / `lib/supabase` から `@/lib/ai` への import は **0 件**
- マスク済み state が DB に書き戻る経路は存在しない（該当関数の呼び出し元がゼロ）
- 回帰テスト追加: COM が副官のとき `processAITurn` には `isAdjutant: true` が渡り、レスポンスだけ `false` になること

## テスト

**742 passed / 49 suites**（基準線 722 から 1 件も落とさず +20）。type-check / lint / build 通過。

## ⚠️ 想定内の副作用

TopHUD と GameStatus の獲得絵札カウンタは `getGameProgress()` がクライアント側で `isAdjutant` を使って計算しています。マスク後は**公開前に副官が取った絵札がナポレオン側に加算されず、公開時に数字が跳ねます**。

裏を返すと「カウンタの増え方から副官が特定できる」という間接漏洩が消えたことになります。勝敗確定と最終スコアはサーバー側の未マスク状態で計算されるため、**ゲーム進行には影響しません**。

## 既知の残課題（本 PR の範囲外）

1. `checkAdjutantRevealed` は進行中トリックでは `revealsAdjutant` フラグしか見ないため、公開が最大3プレイ分遅れます（カード自体は場に見えているので実害小）
2. 結果画面のサイドバー「Teams」が `??? (Hidden)` のまま（見た目の課題）

## 実ブラウザ検証

**未実施**。`vercel dev` に対話的ログインが必要なため、ユニット／コンポーネントテストと静的追跡に限られます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- ae6b2fd fix(security): hide adjutant identity until the designation card is played

## 📁 Files Changed

**Total files changed: 8**

- 🔧 **Source Code**: 4 files
- 🧪 **Tests**: 4 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/components/game/TrickResult.test.tsx`
- `tests/utils/gameUtils.test.ts`
- `tests/app/actions/aiStrategyActions.test.ts`
- `tests/lib/game/maskGameState.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/app/game/[gameId]/page.tsx`
- `src/components/game/TrickResult.tsx`
- `src/lib/game/maskGameState.ts`
- `src/utils/gameUtils.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added
- 💄 **UI/UX** - User interface improvements

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/adjutant-identity-leak
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*