### PR TITLE
fix(security): セッションを2時間のスライディング期限にする

### DIFF
--- a/docs/security/HTTPONLY_COOKIE_MIGRATION.md
+++ b/docs/security/HTTPONLY_COOKIE_MIGRATION.md
@@ -276,10 +276,22 @@ const COOKIE_OPTIONS = {
   httpOnly: true, // ✅ XSS保護: JavaScriptアクセス禁止
   secure: true, // ✅ HTTPS必須
   sameSite: 'strict', // ✅ CSRF保護
-  maxAge: 86400, // 24時間
+  maxAge: SESSION_MAX_AGE_SECONDS, // 7200秒 = 2時間
   path: '/',
 } as const;
 ```
+
+### セッション有効期限（スライディング方式）
+
+- アイドルタイムアウト: **2時間**（`SESSION_DURATION_MS`）
+- 期限は絶対時刻としてクッキーの暗号化ペイロード（`expiresAt`）と
+  `Max-Age` の両方に入る
+- Server Action の認可（`getAuthenticatedPlayerId()`）が成功するたびに
+  「現在時刻 + 2時間」へ延長される。操作し続けている限り失効しない
+- ただし再発行は前回発行から `SESSION_RENEW_INTERVAL_MS`（5分）以上
+  経過した場合のみ。全 Server Action の応答に `Set-Cookie` は付かない
+- そのため実効アイドルタイムアウトは 1時間55分〜2時間の範囲になる
+- 延長は best-effort。`cookies().set()` が失敗しても認可は成功する
 
 ### CSRF保護
 

--- a/src/app/actions/cookieSessionActions.ts
+++ b/src/app/actions/cookieSessionActions.ts
@@ -228,6 +228,12 @@ export async function validateSessionAction(): Promise<
 
 /**
  * セッションをリフレッシュ（有効期限延長）
+ *
+ * 通常の延長は `getAuthenticatedPlayerId()` のスライディング期限
+ * （全 Server Action の認可時に自動延長）が担当するため、この Server Action は
+ * 「操作なしで明示的に延長したい」場合の入口として残している。
+ * 閾値判定を挟まず無条件に再発行するので、ポーリングから呼ばないこと。
+ *
  * @returns リフレッシュされたセッション、または失敗の結果
  */
 export async function refreshSessionAction(): Promise<

--- a/src/hooks/useCookieSession.ts
+++ b/src/hooks/useCookieSession.ts
@@ -130,6 +130,10 @@ export function useCookieSession(): CookieSessionState & CookieSessionActions {
 
   /**
    * セッションをリフレッシュ（有効期限延長）
+   *
+   * 通常はサーバー側のスライディング期限（Server Action の認可時に自動延長）で
+   * 十分なため、この関数を定期実行する必要は無い。
+   * 「操作していないが明示的に延長したい」画面のためのオプション API。
    */
   const refreshWithExtension = useCallback(async () => {
     try {

--- a/src/lib/auth/requireSessionOwner.ts
+++ b/src/lib/auth/requireSessionOwner.ts
@@ -9,6 +9,10 @@
  *   「同じゲームに参加している人間プレイヤーのセッション」が代理で進める。
  *   その場合のみ actor !== target を許可する。
  *
+ * - セッションはスライディング期限。認可が成功するたびに
+ *   `extendSessionIfNeeded()` がクッキーの有効期限を延長する
+ *   （毎回ではなく、前回発行から一定時間が経過した場合のみ）。
+ *
  * 注意: `getSessionCookie()` は Next.js のリクエストスコープ外
  * （headless スクリプト等）では内部で例外を捕捉して null を返す。
  * つまりリクエスト外からこのモジュールを使うと必ず UNAUTHORIZED になる。
@@ -17,7 +21,14 @@
  */
 
 import { AUTH_ERRORS } from '@/lib/constants'
-import { getSessionCookie, isSessionValid } from '@/lib/cookies/sessionCookies'
+import {
+  getSessionCookie,
+  isSessionValid,
+  refreshSession,
+  type SessionCookieData,
+  setSessionCookie,
+  shouldExtendSession,
+} from '@/lib/cookies/sessionCookies'
 import {
   GAME_ACTION_ERROR_CODES,
   GameActionError,
@@ -25,7 +36,33 @@ import {
 import type { GameState } from '@/types/game'
 
 /**
+ * セッションクッキーの有効期限を延長する（スライディング期限・ベストエフォート）
+ *
+ * ⚠️ `cookies().set()` は Server Action / Route Handler の中でしか呼べない。
+ * レンダリング中やリクエストスコープ外（headless シミュレータ等）から
+ * 呼ばれた場合は例外になるが、**延長できなくても認可は成功させる**。
+ * したがってここでは例外を握りつぶし、呼び出し元へ伝播させない。
+ */
+async function extendSessionIfNeeded(
+  session: SessionCookieData
+): Promise<void> {
+  try {
+    if (!shouldExtendSession(session)) {
+      return
+    }
+
+    await setSessionCookie(refreshSession(session))
+  } catch (error) {
+    // 延長失敗は認可の失敗ではない（期限内のセッションはそのまま有効）
+    console.warn('[Auth] Failed to extend session cookie:', error)
+  }
+}
+
+/**
  * 認証済みの操作主体 playerId を取得する（未認証なら null）
+ *
+ * 認可が成功したタイミングでセッションの有効期限を延長する（スライディング期限）。
+ * 全 Server Action がこの関数を通るため、操作し続けている限り失効しない。
  */
 export async function getAuthenticatedPlayerId(): Promise<string | null> {
   const session = await getSessionCookie()
@@ -37,6 +74,8 @@ export async function getAuthenticatedPlayerId(): Promise<string | null> {
   if (!isSessionValid(session)) {
     return null
   }
+
+  await extendSessionIfNeeded(session)
 
   return session.playerId
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -217,8 +217,31 @@ export const SESSION_RATE_LIMIT = { MAX: 10, WINDOW_MS: 60000 } as const
 // プレイヤー名の最大長
 export const PLAYER_NAME_MAX_LENGTH = 50
 
-// Session duration in milliseconds (24 hours)
-export const SESSION_DURATION_MS = 86400000
+// 1秒あたりのミリ秒数（秒/ミリ秒の変換にマジックナンバーを書かないため）
+export const MILLISECONDS_PER_SECOND = 1000
+
+/**
+ * セッションのアイドルタイムアウト（ミリ秒／2時間）
+ *
+ * スライディング期限:
+ * 認可が成功するたびに「最後の操作時刻 + この時間」へ期限が延長される。
+ * したがって操作し続けている限り失効せず、無操作がこの時間続くと失効する。
+ */
+export const SESSION_DURATION_MS = 7200000
+
+// セッションクッキーの Max-Age（秒）。ペイロードの expiresAt と必ず一致させる
+export const SESSION_MAX_AGE_SECONDS =
+  SESSION_DURATION_MS / MILLISECONDS_PER_SECOND
+
+/**
+ * セッションクッキー再発行の最短間隔（ミリ秒／5分）
+ *
+ * 全 Server Action の応答に Set-Cookie を付けないための閾値。
+ * 「残り寿命 < SESSION_DURATION_MS - SESSION_RENEW_INTERVAL_MS」
+ * （＝前回発行から5分以上経過）のときだけ延長する。
+ * 実効アイドルタイムアウトは 1時間55分〜2時間の範囲になる。
+ */
+export const SESSION_RENEW_INTERVAL_MS = 300000
 
 // Supabase Realtime broadcast event names
 export const BROADCAST_EVENTS = {

--- a/src/lib/cookies/sessionCookies.ts
+++ b/src/lib/cookies/sessionCookies.ts
@@ -4,6 +4,11 @@
  */
 
 import { cookies } from 'next/headers'
+import {
+  SESSION_DURATION_MS,
+  SESSION_MAX_AGE_SECONDS,
+  SESSION_RENEW_INTERVAL_MS,
+} from '@/lib/constants'
 import { decryptData, encryptData } from '@/utils/encryption'
 
 export interface SessionCookieData {
@@ -15,7 +20,6 @@ export interface SessionCookieData {
 }
 
 const COOKIE_NAME = 'napoleon_session'
-const COOKIE_MAX_AGE = 86400 // 24時間（秒）
 
 /**
  * クッキーオプション設定
@@ -27,7 +31,7 @@ const getCookieOptions = () => ({
   httpOnly: true,
   secure: true,
   sameSite: 'strict' as const,
-  maxAge: COOKIE_MAX_AGE,
+  maxAge: SESSION_MAX_AGE_SECONDS,
   path: '/',
 })
 
@@ -93,6 +97,10 @@ export function isSessionValid(session: SessionCookieData): boolean {
 
 /**
  * セッション有効期限を延長（リフレッシュ）
+ *
+ * 期限は常に「現在時刻 + SESSION_DURATION_MS」の絶対時刻で書き直す。
+ * 現在時刻起点なので過去の値になることはない。
+ *
  * @param session 既存のセッションデータ
  * @returns 更新されたセッションデータ
  */
@@ -101,6 +109,33 @@ export function refreshSession(session: SessionCookieData): SessionCookieData {
   return {
     ...session,
     createdAt: now,
-    expiresAt: now + COOKIE_MAX_AGE * 1000, // ミリ秒に変換
+    expiresAt: now + SESSION_DURATION_MS,
   }
+}
+
+/**
+ * セッションクッキーを再発行すべきか判定する（スライディング期限）
+ *
+ * 全 Server Action の応答に Set-Cookie を付けるのは無駄なので、
+ * 前回発行から SESSION_RENEW_INTERVAL_MS 以上経過した場合のみ再発行する。
+ *
+ * 残り寿命が SESSION_DURATION_MS を超えている場合も再発行する。
+ * これは新ポリシーより長い期限を持つ旧クッキー（24時間版）や、
+ * 異常に先の時刻が書かれたクッキーを現行ポリシーへ揃えるため。
+ *
+ * @param session 有効期限内のセッションデータ
+ * @param now 判定基準時刻（テスト用。既定は現在時刻）
+ * @returns 再発行すべきなら true
+ */
+export function shouldExtendSession(
+  session: SessionCookieData,
+  now: number = Date.now()
+): boolean {
+  const remainingMs = session.expiresAt - now
+
+  if (remainingMs > SESSION_DURATION_MS) {
+    return true
+  }
+
+  return remainingMs < SESSION_DURATION_MS - SESSION_RENEW_INTERVAL_MS
 }

--- a/tests/app/actions/aiStrategyActions.test.ts
+++ b/tests/app/actions/aiStrategyActions.test.ts
@@ -15,6 +15,9 @@ import type { Card, GameState, Player } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('@/lib/game/gameStateRepository', () => ({

--- a/tests/app/actions/gameActions.test.ts
+++ b/tests/app/actions/gameActions.test.ts
@@ -26,6 +26,9 @@ jest.mock('@/lib/supabase/server', () => ({
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('next/cache', () => ({

--- a/tests/app/actions/gameInitActions.test.ts
+++ b/tests/app/actions/gameInitActions.test.ts
@@ -14,6 +14,9 @@ import type { GameState, Player } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('@/lib/game/gameStateRepository', () => ({

--- a/tests/app/actions/gameLogicActions.test.ts
+++ b/tests/app/actions/gameLogicActions.test.ts
@@ -18,6 +18,9 @@ import type { Card, GameState, NapoleonDeclaration, Player } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('@/lib/game/gameStateRepository', () => ({

--- a/tests/app/actions/gameResultActions.test.ts
+++ b/tests/app/actions/gameResultActions.test.ts
@@ -15,6 +15,9 @@ import type { GameResult, GameState } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('@/lib/game/gameStateRepository', () => ({

--- a/tests/app/actions/gameRoomActions.test.ts
+++ b/tests/app/actions/gameRoomActions.test.ts
@@ -22,6 +22,9 @@ import type { GameRoom } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('@/lib/supabase/server', () => ({

--- a/tests/app/actions/gameStateActions.test.ts
+++ b/tests/app/actions/gameStateActions.test.ts
@@ -10,6 +10,9 @@ import type { GameState } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('@/lib/supabase/server', () => ({

--- a/tests/app/actions/serverActionAuthorization.test.ts
+++ b/tests/app/actions/serverActionAuthorization.test.ts
@@ -34,6 +34,9 @@ import type { Card, GameResult, GameState, Player } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 jest.mock('next/cache', () => ({

--- a/tests/lib/auth/requireSessionOwner.test.ts
+++ b/tests/lib/auth/requireSessionOwner.test.ts
@@ -11,6 +11,12 @@ import {
 } from '@/lib/auth/requireSessionOwner'
 import { AUTH_ERRORS, GAME_PHASES } from '@/lib/constants'
 import {
+  refreshSession,
+  type SessionCookieData,
+  setSessionCookie,
+  shouldExtendSession,
+} from '@/lib/cookies/sessionCookies'
+import {
   GAME_ACTION_ERROR_CODES,
   GameActionError,
 } from '@/lib/errors/GameActionError'
@@ -19,9 +25,13 @@ import type { GameState, Player } from '@/types/game'
 jest.mock('@/lib/cookies/sessionCookies', () => ({
   getSessionCookie: jest.fn(),
   isSessionValid: jest.fn(),
+  refreshSession: jest.fn(),
+  setSessionCookie: jest.fn(),
+  shouldExtendSession: jest.fn(),
 }))
 
 import {
+  createSessionData,
   mockAuthenticatedSession,
   mockExpiredSession,
   mockNoSession,
@@ -80,6 +90,71 @@ describe('requireSessionOwner helpers', () => {
       mockExpiredSession('human-1')
 
       await expect(getAuthenticatedPlayerId()).resolves.toBeNull()
+    })
+  })
+
+  describe('スライディング期限の延長（getAuthenticatedPlayerId）', () => {
+    const refreshedSession = (playerId: string): SessionCookieData => ({
+      ...createSessionData(playerId),
+      expiresAt: Date.now() + 1,
+    })
+
+    it('re-issues the cookie when the renew threshold has been crossed', async () => {
+      mockAuthenticatedSession('human-1')
+      const refreshed = refreshedSession('human-1')
+      ;(shouldExtendSession as jest.Mock).mockReturnValue(true)
+      ;(refreshSession as jest.Mock).mockReturnValue(refreshed)
+      ;(setSessionCookie as jest.Mock).mockResolvedValue(undefined)
+
+      await expect(getAuthenticatedPlayerId()).resolves.toBe('human-1')
+      expect(setSessionCookie).toHaveBeenCalledTimes(1)
+      expect(setSessionCookie).toHaveBeenCalledWith(refreshed)
+    })
+
+    it('does NOT re-issue the cookie below the renew threshold', async () => {
+      mockAuthenticatedSession('human-1')
+      ;(shouldExtendSession as jest.Mock).mockReturnValue(false)
+
+      await expect(getAuthenticatedPlayerId()).resolves.toBe('human-1')
+      expect(refreshSession).not.toHaveBeenCalled()
+      expect(setSessionCookie).not.toHaveBeenCalled()
+    })
+
+    it('does NOT re-issue an expired cookie', async () => {
+      mockExpiredSession('human-1')
+      ;(shouldExtendSession as jest.Mock).mockReturnValue(true)
+
+      await expect(getAuthenticatedPlayerId()).resolves.toBeNull()
+      expect(setSessionCookie).not.toHaveBeenCalled()
+    })
+
+    it('still authorizes when cookies().set() throws (render path fallback)', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+      mockAuthenticatedSession('human-1')
+      ;(shouldExtendSession as jest.Mock).mockReturnValue(true)
+      ;(refreshSession as jest.Mock).mockReturnValue(
+        refreshedSession('human-1')
+      )
+      ;(setSessionCookie as jest.Mock).mockRejectedValue(
+        new Error(
+          'Cookies can only be modified in a Server Action or Route Handler'
+        )
+      )
+
+      await expect(getAuthenticatedPlayerId()).resolves.toBe('human-1')
+      await expect(requireSessionOwner('human-1')).resolves.toBe('human-1')
+      expect(warnSpy).toHaveBeenCalled()
+    })
+
+    it('still authorizes when the extension helper itself is unavailable', async () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation()
+      mockAuthenticatedSession('human-1')
+      ;(shouldExtendSession as jest.Mock).mockImplementation(() => {
+        throw new Error('unexpected')
+      })
+
+      await expect(getAuthenticatedPlayerId()).resolves.toBe('human-1')
+      expect(warnSpy).toHaveBeenCalled()
     })
   })
 

--- a/tests/lib/cookies/sessionCookies.test.ts
+++ b/tests/lib/cookies/sessionCookies.test.ts
@@ -2,11 +2,15 @@
  * セッションクッキーユーティリティのユニットテスト
  */
 
+import { SESSION_DURATION_MS, SESSION_RENEW_INTERVAL_MS } from '@/lib/constants'
 import {
   isSessionValid,
   refreshSession,
   type SessionCookieData,
+  shouldExtendSession,
 } from '@/lib/cookies/sessionCookies'
+
+const ONE_MINUTE_MS = 60000
 
 describe('Session Cookie Utilities', () => {
   describe('isSessionValid', () => {
@@ -65,8 +69,8 @@ describe('Session Cookie Utilities', () => {
         playerId: 'test-123',
         playerName: 'TestPlayer',
         sessionToken: 'token-123',
-        createdAt: Date.now() - 43200000, // 12時間前
-        expiresAt: Date.now() + 43200000, // 12時間後
+        createdAt: Date.now() - SESSION_DURATION_MS / 2, // 1時間前に発行
+        expiresAt: Date.now() + SESSION_DURATION_MS / 2, // 残り1時間
       }
 
       const refreshed = refreshSession(originalSession)
@@ -79,9 +83,12 @@ describe('Session Cookie Utilities', () => {
       // createdAtが更新される
       expect(refreshed.createdAt).toBeGreaterThan(originalSession.createdAt)
 
-      // expiresAtが24時間後に更新される
-      const expectedExpiry = refreshed.createdAt + 86400000
+      // expiresAtがアイドルタイムアウト分だけ先に更新される
+      const expectedExpiry = refreshed.createdAt + SESSION_DURATION_MS
       expect(Math.abs(refreshed.expiresAt - expectedExpiry)).toBeLessThan(100) // 100ms以内の誤差許容
+
+      // 期限が過去になることは無い
+      expect(refreshed.expiresAt).toBeGreaterThan(Date.now())
     })
 
     it('should create new timestamps while preserving session data', () => {
@@ -116,6 +123,136 @@ describe('Session Cookie Utilities', () => {
       const refreshed = refreshSession(expiredSession)
 
       expect(isSessionValid(refreshed)).toBe(true)
+    })
+  })
+
+  describe('shouldExtendSession（再発行の閾値判定）', () => {
+    const NOW = 1700000000000
+
+    const sessionExpiringAt = (expiresAt: number): SessionCookieData => ({
+      playerId: 'test-123',
+      playerName: 'TestPlayer',
+      sessionToken: 'token-123',
+      createdAt: expiresAt - SESSION_DURATION_MS,
+      expiresAt,
+    })
+
+    it('does not re-issue a freshly issued cookie', () => {
+      const session = sessionExpiringAt(NOW + SESSION_DURATION_MS)
+
+      expect(shouldExtendSession(session, NOW)).toBe(false)
+    })
+
+    it('does not re-issue before the renew interval has elapsed', () => {
+      // 前回発行から「再発行間隔 - 1分」しか経っていない
+      const elapsed = SESSION_RENEW_INTERVAL_MS - ONE_MINUTE_MS
+      const session = sessionExpiringAt(NOW + SESSION_DURATION_MS - elapsed)
+
+      expect(shouldExtendSession(session, NOW)).toBe(false)
+    })
+
+    it('re-issues once the renew interval has elapsed', () => {
+      // 前回発行から「再発行間隔 + 1分」経過
+      const elapsed = SESSION_RENEW_INTERVAL_MS + ONE_MINUTE_MS
+      const session = sessionExpiringAt(NOW + SESSION_DURATION_MS - elapsed)
+
+      expect(shouldExtendSession(session, NOW)).toBe(true)
+    })
+
+    it('re-issues a nearly expired cookie', () => {
+      const session = sessionExpiringAt(NOW + ONE_MINUTE_MS)
+
+      expect(shouldExtendSession(session, NOW)).toBe(true)
+    })
+
+    it('re-issues a legacy cookie whose expiry exceeds the current policy', () => {
+      // 旧ポリシー（24時間）のクッキーは現行ポリシーへ縮めて揃える
+      const legacyDurationMs = 86400000
+      const session = sessionExpiringAt(NOW + legacyDurationMs)
+
+      expect(shouldExtendSession(session, NOW)).toBe(true)
+    })
+  })
+
+  describe('スライディング期限（2時間アイドルタイムアウト）', () => {
+    const START = 1700000000000
+
+    const issueSession = (): SessionCookieData => ({
+      playerId: 'test-123',
+      playerName: 'TestPlayer',
+      sessionToken: 'token-123',
+      createdAt: Date.now(),
+      expiresAt: Date.now() + SESSION_DURATION_MS,
+    })
+
+    /** 活動1回分（認可成功時の延長処理）を再現する */
+    const act = (session: SessionCookieData): SessionCookieData =>
+      shouldExtendSession(session) ? refreshSession(session) : session
+
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(START)
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('stays valid indefinitely while the player keeps acting', () => {
+      let session = issueSession()
+
+      // 30分間隔で5時間活動し続ける（固定24時間ならこの時点でも有効だが、
+      // ここで見たいのは「延長されているので失効しない」こと）
+      for (let i = 0; i < 10; i += 1) {
+        jest.advanceTimersByTime(30 * ONE_MINUTE_MS)
+        session = act(session)
+        expect(isSessionValid(session)).toBe(true)
+      }
+
+      // 最後の活動時刻から2時間先まではまだ有効
+      expect(session.expiresAt).toBe(Date.now() + SESSION_DURATION_MS)
+    })
+
+    it('survives an idle gap shorter than the effective idle timeout', () => {
+      let session = issueSession()
+
+      // 実効アイドルタイムアウトの下限（2時間 - 再発行間隔）より短い無活動
+      jest.advanceTimersByTime(
+        SESSION_DURATION_MS - SESSION_RENEW_INTERVAL_MS - ONE_MINUTE_MS
+      )
+
+      expect(isSessionValid(session)).toBe(true)
+
+      session = act(session)
+
+      expect(session.expiresAt).toBe(Date.now() + SESSION_DURATION_MS)
+    })
+
+    it('expires after 2 hours of inactivity', () => {
+      const session = issueSession()
+
+      jest.advanceTimersByTime(SESSION_DURATION_MS - ONE_MINUTE_MS)
+      expect(isSessionValid(session)).toBe(true)
+
+      jest.advanceTimersByTime(ONE_MINUTE_MS)
+      expect(isSessionValid(session)).toBe(false)
+    })
+
+    it('expires 2 hours after the LAST activity, not after creation', () => {
+      let session = issueSession()
+
+      // 1時間後に活動 → 期限が「その時刻 + 2時間」へ延びる
+      jest.advanceTimersByTime(60 * ONE_MINUTE_MS)
+      session = act(session)
+      const lastActivityAt = Date.now()
+
+      // 作成から2時間1分後（＝旧仕様の期限切れ相当）でもまだ有効
+      jest.advanceTimersByTime(61 * ONE_MINUTE_MS)
+      expect(isSessionValid(session)).toBe(true)
+
+      // 最終活動から2時間経過すると失効する
+      jest.setSystemTime(lastActivityAt + SESSION_DURATION_MS)
+      expect(isSessionValid(session)).toBe(false)
     })
   })
 

--- a/tests/utils/sessionTestUtils.ts
+++ b/tests/utils/sessionTestUtils.ts
@@ -7,8 +7,15 @@
  * jest.mock('@/lib/cookies/sessionCookies', () => ({
  *   getSessionCookie: jest.fn(),
  *   isSessionValid: jest.fn(),
+ *   refreshSession: jest.fn(),
+ *   setSessionCookie: jest.fn(),
+ *   shouldExtendSession: jest.fn(),
  * }))
  * ```
+ *
+ * `refreshSession` / `setSessionCookie` / `shouldExtendSession` は
+ * `getAuthenticatedPlayerId()` のスライディング期限延長で使われる。
+ * 既定では `shouldExtendSession` が undefined を返すため延長は発生しない。
  */
 
 import type { SessionCookieData } from '@/lib/cookies/sessionCookies'


### PR DESCRIPTION
## 背景

セッションクッキーは発行から **24時間の固定期限**で、活動しても延長されない実装でした。カードゲームのセッションとしては長すぎ、5分プレイして放置しただけのクッキーも24時間有効なままです。盗用・複製された場合の窓がそのまま24時間になります。

延長機構（`refreshSessionAction` / `useCookieSession.refreshWithExtension`）は実装されていましたが、**components / app / contexts のどこからも呼ばれていないデッドコード**でした。

## 変更

**アイドルタイムアウト2時間のスライディング期限**にします。活動している限り切れず、無活動なら2時間で失効します。

- `SESSION_DURATION_MS` を 7200000（2時間）に
- `sessionCookies.ts` のローカル定数 `COOKIE_MAX_AGE = 86400` を**削除**。Max-Age を `SESSION_DURATION_MS` から導出（従来は `expiresAt` 用と Max-Age 用で**別ファイルに二重管理**されていた）
- 認可成功後に `extendSessionIfNeeded()` で延長。**期限切れセッションは延長しない**（先に return するため）

## 再発行の閾値: 前回発行から5分

閾値方式では **実効アイドルタイムアウト = TTL − 再発行間隔** になります。

| 方式 | 実効アイドルタイムアウト | 要件からのずれ |
| --- | --- | --- |
| 「残り半分で延長」 | 1時間〜2時間 | **最大 50%** |
| **前回発行から5分（採用）** | 1時間55分〜2時間 | **4%** |

Set-Cookie は1セッションあたり最大5分に1回です。待機画面は2秒間隔ポーリング（5分で150回の認可）ですが、Set-Cookie は1回に収まります。

**移行措置**: 残り寿命が `SESSION_DURATION_MS` を超えるクッキー（＝現在出回っている24時間もの）も再発行対象にしているため、デプロイ後の最初の認可で2時間へ縮みます。

## レンダリング経路での `cookies().set()`

`cookies().set()` はレンダリング中に呼ぶと例外になります。現状呼ばれないことを4点で確認しました。

- `requireSessionOwner` 系のインポート元は `src/app/actions/` の7ファイルのみで、全て `'use server'`
- `src/app` 配下の page は全て `'use client'`。非クライアントの React ファイル3つはセッションを import していない
- `src/middleware.ts` は存在せず、Route Handler も0件
- `pnpm build` で `/`・`/reset-session`・`/rooms` の静的プリレンダリングが成功（レンダリング時にクッキー書き込みが走っていない実証）

その上で **`extendSessionIfNeeded()` は全体を try/catch で囲み、延長に失敗しても認可は成功させます**。`cookies().set()` が throw しても認可が通ることをテストで検証済み。

## COM・シミュレータへの影響なし

- **`pnpm sim 2` が2局とも完走**（napoleon_win=1 / allied_win=1）。出力を `[Auth]|cookie|session|request scope` で grep して一致ゼロ＝シミュレータはセッション経路に触れていない
- COM 代理判定（`assertCanActAsPlayer`）は無変更。延長は認可成功後に走るため、COM 代理操作でも人間側のセッションが延びます（意図通り）

## テスト

**771 passed / 52 suites**（基準線 757 から +14、落ちたもの 0）。

fake timers で「30分間隔で5時間活動しても失効しない」「2時間無活動で失効」「作成から2時間超でも最終活動から2時間以内なら有効」を検証。閾値未満で `setSessionCookie` が呼ばれないこと、期限切れは延長しないことも含みます。

type-check / lint / format / build 通過。

## 既知の残存リスク

1. **待機画面（`/rooms/[roomId]/waiting`）は2秒間隔で `getRoomDetailsAction` をポーリングし、これが `requireSessionOwner` を通ります。** そのタブを開きっぱなしにすると無操作でもセッションが延び続けます。厳密にするならポーリング系を延長対象から外す設計が必要です
2. 実効アイドルタイムアウトは正確に2時間ではなく **1時間55分〜2時間**（閾値方式の構造的な帰結）
3. `gameActions.validateSessionAction` に残る **DB 側の別の24時間判定**（`players.created_at` ベース）はスコープ外で未変更。クッキー側2時間と不整合のままです
4. 現在有効な24時間クッキーはデプロイ後の最初の認可で2時間に縮むため、長時間放置中のユーザーは想定より早くログアウトします（意図通り）

## `refreshSessionAction` / `useCookieSession`

削除せず残しました。既存テストでカバーされた公開 API であり、本番認可の変更と同時に API 削除まで抱き合わせるとリスクが増えるためです。ただし**「定期実行不要・ポーリングから呼ばないこと（閾値判定なしで無条件再発行するため）」**という doc コメントを追加しています。

## 実ブラウザ検証

**未実施。** `vercel dev` には実 Supabase 認証情報が必要なため、`next dev`（モック env）で `/` と `/rooms` が HTTP 200 を返すことのみ確認しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 213ecd7 feat(security): セッション有効期限をスライディング方式にする

## 📁 Files Changed

**Total files changed: 17**

- 🔧 **Source Code**: 5 files
- 🧪 **Tests**: 11 files
- 📚 **Documentation**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/app/actions/aiStrategyActions.test.ts`
- `tests/app/actions/gameActions.test.ts`
- `tests/app/actions/gameInitActions.test.ts`
- `tests/app/actions/gameLogicActions.test.ts`
- `tests/app/actions/gameResultActions.test.ts`
- `tests/app/actions/gameRoomActions.test.ts`
- `tests/app/actions/gameStateActions.test.ts`
- `tests/app/actions/serverActionAuthorization.test.ts`
- `tests/lib/auth/requireSessionOwner.test.ts`
- `tests/lib/cookies/sessionCookies.test.ts`
- `tests/utils/sessionTestUtils.ts`

#### 📚 Documentation

- `docs/security/HTTPONLY_COOKIE_MIGRATION.md`

#### 🔧 Source Code

- `src/app/actions/cookieSessionActions.ts`
- `src/hooks/useCookieSession.ts`
- `src/lib/auth/requireSessionOwner.ts`
- `src/lib/constants.ts`
- `src/lib/cookies/sessionCookies.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added
- 💄 **UI/UX** - User interface improvements
- 📝 **Documentation** - Documentation updates

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/sliding-session-expiry
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*