### PR TITLE
chore(deps): next を 16.2.12 に更新し、TypeScript 7 と Python 依存の扱いを整理

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,32 @@ updates:
       include: "scope"
     # バージョニング戦略
     versioning-strategy: increase-if-necessary
+    # 更新を無視する設定
+    #
+    # typescript のメジャー更新（6.x → 7.x）は保留中。
+    # 調査結果（TypeScript 7.0.2 / next 16.2.11・16.2.12 で確認済み）:
+    #   - このリポジトリのコード自体は TS 7 と完全互換。
+    #     `pnpm type-check` は 0 エラー、`pnpm test:ci` も全件合格した。
+    #   - ブロッカーは Next.js 側。TypeScript 7 は Go 実装への書き換えに伴い
+    #     JS の Compiler API を提供しなくなり、その API を直接呼んで型チェックを
+    #     行っている `next build` が失敗する。
+    #     next 16.2.12 のエラーメッセージ:
+    #       "TypeScript 7.0.2 does not provide the compiler API required by
+    #        Next.js. Enable experimental.useTypeScriptCli in your Next.js
+    #        config to use the TypeScript CLI, or install TypeScript 6 instead."
+    #   - next 16.2.12 + `experimental.useTypeScriptCli: true` ではビルド成功を
+    #     実証済み。ただし experimental フラグ依存になるため採用は見送った。
+    #   - 上記フラグが experimental でなくなったら（または Next.js が TS 7 を
+    #     標準サポートしたら）この ignore を外して TS 7 に上げられる。
+    #
+    # 注意: 下の dev-dependencies グループは update-types を minor/patch に
+    # 絞っているが、これは「グループにまとめる対象」を絞るだけで、対象外の
+    # メジャー更新は単独 PR として別に作成される（実際に TS 7.0.2 の PR が
+    # 作られた）。メジャー更新を止めるにはこの ignore が必要。
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"
     # グループ化（関連するパッケージをまとめる）
     groups:
       next-dependencies:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,27 @@ updates:
       prefix-development: "chore"
       include: "scope"
     versioning-strategy: increase-if-necessary
+    # グループ化
+    #
+    # 下の 3 グループは pyproject.toml に直接書かれたパッケージ名しか列挙して
+    # いないため、uv.lock 経由で入る推移的依存（hf-xet / tqdm / filelock /
+    # websockets / idna / hpack / click / typer / scipy など）がどのグループにも
+    # 一致せず、1 パッケージ 1 PR で大量に開く状態だった（実測: 2026-07 に
+    # PR #486〜#494 の 9 件が個別 PR、グループ PR は #485 の ml-serving 1 件のみ）。
+    # pip の更新は全て python/uv.lock を書き換えるので、PR が並ぶと 1 件マージ
+    # するたびに残り全部が競合し、rebase と CI 再実行を繰り返すことになる。
+    #
+    # そこで受け皿として python-dependencies（patterns: "*"）を最後に追加する。
+    # Dependabot は「あるパッケージが複数のグループに一致する場合、最初に一致した
+    # グループに入れる」仕様のため、この catch-all を末尾に置く限り上の 3 グループ
+    # の割り当ては変わらない（ml-serving 等は従来どおり独立した PR になる）。
+    #
+    # update-types は敢えて絞っていない。絞るとグループ対象外になった major が
+    # 個別 PR として復活し、この設定の目的（PR 件数の削減）を損なうため
+    # （npm 側の typescript と同じ構造）。実例として websockets 15.0.1 → 16.1
+    # は major であり、minor/patch に絞ると単独 PR のままになる。
+    # major を個別にレビューしたい場合は cooldown の semver-major-days: 14 が
+    # 時間差を作るので、そこで気付ける。
     groups:
       ml-dependencies:
         patterns:
@@ -121,6 +142,11 @@ updates:
       supabase-python:
         patterns:
           - "supabase"
+      # 上のどれにも一致しなかった残り全部（推移的依存・dev ツール含む）。
+      # 必ず最後に置くこと。先頭に置くと全パッケージを飲み込んでしまう。
+      python-dependencies:
+        patterns:
+          - "*"
 
   # GitHub Actions の監視
   - package-ecosystem: "github-actions"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.101.1",
     "crypto-js": "^4.2.0",
-    "next": "16.2.11",
+    "next": "16.2.12",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^4.2.0
         version: 4.2.0
       next:
-        specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.2.12
+        version: 16.2.12(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.4
         version: 19.2.7
@@ -806,53 +806,53 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.2.11':
-    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
+  '@next/env@16.2.12':
+    resolution: {integrity: sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==}
 
-  '@next/swc-darwin-arm64@16.2.11':
-    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
+  '@next/swc-darwin-arm64@16.2.12':
+    resolution: {integrity: sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.11':
-    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
+  '@next/swc-darwin-x64@16.2.12':
+    resolution: {integrity: sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.11':
-    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
+  '@next/swc-linux-arm64-gnu@16.2.12':
+    resolution: {integrity: sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@16.2.11':
-    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
+  '@next/swc-linux-arm64-musl@16.2.12':
+    resolution: {integrity: sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@16.2.11':
-    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
+  '@next/swc-linux-x64-gnu@16.2.12':
+    resolution: {integrity: sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@16.2.11':
-    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
+  '@next/swc-linux-x64-musl@16.2.12':
+    resolution: {integrity: sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@16.2.11':
-    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
+  '@next/swc-win32-arm64-msvc@16.2.12':
+    resolution: {integrity: sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.11':
-    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
+  '@next/swc-win32-x64-msvc@16.2.12':
+    resolution: {integrity: sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1990,8 +1990,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.2.11:
-    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
+  next@16.2.12:
+    resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -3202,30 +3202,30 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@next/env@16.2.11': {}
+  '@next/env@16.2.12': {}
 
-  '@next/swc-darwin-arm64@16.2.11':
+  '@next/swc-darwin-arm64@16.2.12':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.11':
+  '@next/swc-darwin-x64@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.11':
+  '@next/swc-linux-arm64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.11':
+  '@next/swc-linux-arm64-musl@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.11':
+  '@next/swc-linux-x64-gnu@16.2.12':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.11':
+  '@next/swc-linux-x64-musl@16.2.12':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.11':
+  '@next/swc-win32-arm64-msvc@16.2.12':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.11':
+  '@next/swc-win32-x64-msvc@16.2.12':
     optional: true
 
   '@pkgjs/parseargs@0.11.0':
@@ -4509,9 +4509,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.11(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.12(@babel/core@7.29.0)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.2.11
+      '@next/env': 16.2.12
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.43
       caniuse-lite: 1.0.30001805
@@ -4520,14 +4520,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.11
-      '@next/swc-darwin-x64': 16.2.11
-      '@next/swc-linux-arm64-gnu': 16.2.11
-      '@next/swc-linux-arm64-musl': 16.2.11
-      '@next/swc-linux-x64-gnu': 16.2.11
-      '@next/swc-linux-x64-musl': 16.2.11
-      '@next/swc-win32-arm64-msvc': 16.2.11
-      '@next/swc-win32-x64-msvc': 16.2.11
+      '@next/swc-darwin-arm64': 16.2.12
+      '@next/swc-darwin-x64': 16.2.12
+      '@next/swc-linux-arm64-gnu': 16.2.12
+      '@next/swc-linux-arm64-musl': 16.2.12
+      '@next/swc-linux-x64-gnu': 16.2.12
+      '@next/swc-linux-x64-musl': 16.2.12
+      '@next/swc-win32-arm64-msvc': 16.2.12
+      '@next/swc-win32-x64-msvc': 16.2.12
       '@playwright/test': 1.61.1
       sharp: 0.34.5
     transitivePeerDependencies:


### PR DESCRIPTION
## 1. Next.js 16.2.11 → 16.2.12

TypeScript は 6.0.3 のまま、`next.config.js` も未変更です。ロックファイルの差分は `next` と `@next/*` のみで、他パッケージの巻き込み更新が 0 件であることを確認済み。

このバージョンの価値は後述の TypeScript 7 の件にあります。

## 2. TypeScript のメジャー更新を Dependabot の対象外に

Dependabot が TypeScript 6.0.3 → 7.0.2 の PR (#482) を出しましたが、調査の上で見送りました。

**このリポジトリのコードは TypeScript 7 に完全互換です。**

| チェック | TS 7.0.2 |
| --- | --- |
| `type-check` | ✅ **0 エラー** |
| `test:ci` | ✅ **846 件全合格** |
| `build` | ❌ 失敗 |

ビルドだけが失敗します。原因はコードではなく、**TypeScript 7 が JS の Compiler API を提供しなくなった**ことです（Go 実装への書き換えのため）。Next.js は従来この API を直接呼んで型チェックしていました。

next 16.2.11 では `The "id" argument must be of type string. Received undefined` という不明瞭なクラッシュになりますが、**16.2.12 では明確なメッセージが出ます**。

```
TypeScript 7.0.2 does not provide the compiler API required by Next.js.
Enable experimental.useTypeScriptCli in your Next.js config to use the
TypeScript CLI, or install TypeScript 6 instead.
```

**next 16.2.12 + `experimental.useTypeScriptCli: true` でビルドが通ることは実証済み**です。それでも採用しないのは、**本番ビルドの型チェック経路を experimental フラグに依存させたくない**ためです。フラグが experimental でなくなった時点で、バージョンを上げるだけで移行できます（コード修正は不要と実証済み）。

```yaml
ignore:
  - dependency-name: "typescript"
    update-types:
      - "version-update:semver-major"
```

**なぜ groups だけでは不十分か**: `dev-dependencies` グループは `patterns` に `typescript` を含み `update-types: [minor, patch]` に絞っていますが、これは「グループにまとめる対象」を絞るだけで、対象外（major）を抑止しません。**除外された major は単独 PR として別に作られます** — PR #482 がこの設定下で作られたことがその実証です。したがって update エントリ直下の `ignore` が必要です。

TS 8 以降も同様に無視されます。根本原因（Next.js が JS Compiler API を必要とする）が TS 7 以降ずっと続く性質のものなので、メジャー全体を止める方が実態に合うと判断しました。解除タイミングは設定ファイルのコメントに明記しています。

## 3. Python 依存を1 PR にまとめる

**pip ブロックには既に3グループ（`ml-dependencies` / `ml-serving` / `supabase-python`）が存在します**が、これらは `pyproject.toml` に直接書かれたパッケージ名しか列挙していません。`uv.lock` 経由で入る**推移的依存**はどのパターンにも一致せず、Dependabot の既定動作「どのルールにも一致しない依存は個別 PR」に落ちていました。**scipy すら scikit-learn の推移的依存**で `pyproject.toml` に記載がありません。

実際、直近の Python PR 10件のうち、グループ化されていたのは fastapi (#485) の1件のみで、**残り9件は個別 PR**でした。

受け皿として `python-dependencies`（`patterns: ["*"]`）を**末尾に**追加しています。既存3グループは1行も変更していません（26行の純増、削除0）。

**末尾配置が要点です。** GitHub 公式ドキュメントに「複数ルールに一致する依存は**最初に一致したグループ**に入る」と明記されているため、catch-all を先頭に置くと既存グループを全て飲み込みます。この警告も設定ファイルにコメントとして残しました。

**`update-types` を絞らなかった理由**: 絞ると対象外の major が個別 PR として復活し、目的（件数削減）を損ないます — TypeScript とまったく同じ構造です。実例として **#491 の websockets 15.0.1 → 16.1 は semver-major** で、minor/patch に絞れば単独 PR のまま残っていました。major を時間差で扱う要求は既存の `cooldown.semver-major-days: 14` が吸収します。

**効果は次回以降です。** 既存 PR には遡及しません。今週と同条件なら 10本 → 2本になる見込みです。

## テスト

**846 tests / 57 suites 全合格**、type-check / lint / format / build 通過。

## 未検証

**Dependabot を実際に走らせての確認はできていません**（ローカルでは不可）。確認したのは YAML の妥当性・構造・グループ順序・公式ドキュメントの割り当て仕様・現在の PR 実測データまでです。

効果は次回の Dependabot 実行時（毎週月曜）に PR 件数を見れば判定できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 4327516 ci(deps): group leftover pip updates into one PR
- f8cdd9a chore(deps): bump next to 16.2.12 and defer TypeScript 7 majors

## 📁 Files Changed

**Total files changed: 3**

- ⚙️ **Configuration**: 3 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/dependabot.yml`
- `package.json`
- `pnpm-lock.yaml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*