### PR TITLE
chore(claude): 作業ファイルを /tmp ではなくリポジトリ内に置くルールを追加

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -291,6 +291,20 @@ terraform plan  # 変更内容を確認
 - SHALL limit response token length to avoid usage limit.
 - SHALL break down large files for stepwise parsing.
 
+### 作業ファイルの置き場所
+
+**`/tmp` および `/private/tmp` を使わないこと。** ハーネスがセッション用の
+スクラッチパッドとして `/private/tmp/...` を提示してくるが、このプロジェクトでは
+使用しない。
+
+- git worktree → `.claude/worktrees/<名前>`（`.gitignore` 済み）
+- 一時スクリプト・検証用の使い捨てファイル → 作業対象の worktree 内、
+  もしくは `.claude/worktrees/` 配下
+
+worktree で `pnpm` を動かす場合は `node_modules` を symlink する:
+`ln -sfn /Users/kk/napoleon-game-4players/node_modules <worktree>/node_modules`
+（コミット前に symlink を消してから `git worktree remove` すること）
+
 ### エージェント編成（既定）
 
 実装を伴う作業は、原則として `agent-flow` skill の編成で進めること。


### PR DESCRIPTION
## 何をしたか

`.claude/CLAUDE.md` に「作業ファイルの置き場所」セクションを追加。ドキュメントのみの変更。

## なぜ

ハーネスがセッションごとに `/private/tmp/...` をスクラッチパッドとして提示してくるため、何も指定しないと git worktree や検証用スクリプトがそこに作られる。ユーザーの管理外の場所であり、意図した挙動ではないので明示的に禁止する。

## 内容

- `/tmp` と `/private/tmp` を使わない
- git worktree は `.claude/worktrees/<名前>` に置く
- 一時スクリプトも worktree 内か `.claude/worktrees/` 配下に置く
- worktree で `pnpm` を動かすための `node_modules` symlink 手順を併記

## 確認

`.claude/worktrees/` 配下に worktree が2つある状態で `pnpm lint` を実行し、走査対象が 193 ファイルのまま変化しないことを確認した（`.gitignore` 済みのため biome が入り込まない）。`.gitignore:132-133` に「nested biome.json breaks pnpm lint」というコメントがあり懸念していた点。

node_modules の symlink 手順を書いたのは、これを踏まないと pre-commit hook が `jest: command not found` で落ちるため（実際に踏んだ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- de8768a chore(claude): 作業ファイルを /tmp ではなくリポジトリ内に置くルールを追加

## 📁 Files Changed

**Total files changed: 1**

- 📚 **Documentation**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation

- `.claude/CLAUDE.md`

#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 📝 **Documentation** - Documentation updates

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*