### PR TITLE
docs(claude): 一時ファイル規則に、ハーネス側のパスは変更できない旨を追記

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -305,6 +305,14 @@ worktree で `pnpm` を動かす場合は `node_modules` を symlink する:
 `ln -sfn /Users/kk/napoleon-game-4players/node_modules <worktree>/node_modules`
 （コミット前に symlink を消してから `git worktree remove` すること）
 
+**例外: Claude Code 自身が書き出すファイルは対象外。** サブエージェントの
+トランスクリプト（`/private/tmp/claude-<uid>/.../tasks/*.output`）とセッション
+スクラッチパッドはハーネスが場所を決めており、環境変数でも settings.json でも
+変更できない。`CLAUDE_CODE_TMPDIR` は実機で効果がなく、関連 issue も
+anthropics/claude-code#17936 と #25292 がいずれも not planned でクローズ済み。
+**この調査を繰り返さないこと。** 気になる場合はセッション終了後に
+`/private/tmp/claude-*` を削除する。
+
 ### エージェント編成（既定）
 
 実装を伴う作業は、原則として `agent-flow` skill の編成で進めること。


### PR DESCRIPTION
## 何をしたか

#503 で追加した「作業ファイルの置き場所」セクションに、例外の注記を1段落追加。ドキュメントのみ。

## なぜ

#503 の規則が適用されるのは**自分で作るファイル**だけ。Claude Code がサブエージェントのトランスクリプトとセッションスクラッチパッドを書き出す `/private/tmp/claude-<uid>/...` は**ハーネスが場所を決めており、こちらからは動かせない**。

規則だけを読むと「まだ `/private/tmp` が使われている、直さねば」と読めてしまい、実際に設定変更の可否を調べ直す動きが出た。結論は「変更不可」なので、調査済みの事実として書き残す。

## 調査結果（この注記の根拠）

- `CLAUDE_CODE_TMPDIR` を設定して実機で試したが効果なし
- 関連 issue はいずれもクローズ済み
  - [anthropics/claude-code#17936](https://github.com/anthropics/claude-code/issues/17936)（`CLAUDE_CODE_TMPDIR` をセッションスクラッチパッドに適用）→ **not planned**
  - [anthropics/claude-code#25292](https://github.com/anthropics/claude-code/issues/25292)（セッション固有の一時ディレクトリ）→ **not planned**
  - [anthropics/claude-code#18679](https://github.com/anthropics/claude-code/issues/18679)（`CLAUDE_TMPDIR`）→ duplicate
- `settings.json` に該当する設定キーは存在しない

調査の限界として、公式ドキュメント（code.claude.com）は取得できず、判断は GitHub issue の状態と実機テストに基づく。

## 補足

この一時ディレクトリにはコード内容やプロジェクト構造が書き込まれる。気になる場合はセッション終了後に `/private/tmp/claude-*` を削除するのが現実的な対処、という点も併記した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 419eb83 docs(claude): 一時ファイル規則に、ハーネス側のパスは変更できない旨を追記

## 📁 Files Changed

**Total files changed: 1**

- 📚 **Documentation**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation

- `.claude/CLAUDE.md`

#### 🔧 Source Code


#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 📝 **Documentation** - Documentation updates

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*