### PR TITLE
fix(game): マスク済み state で終了判定してゲームが誤って終わる問題を直す

### DIFF
--- a/src/app/actions/gameLogicActions.ts
+++ b/src/app/actions/gameLogicActions.ts
@@ -1,6 +1,5 @@
 'use server'
 
-import { processAIPlayingPhase } from '@/lib/ai/gameTricks'
 import {
   assertCanActAsPlayer,
   requireAuthenticatedPlayerId,
@@ -19,6 +18,7 @@ import {
   getCurrentPlayer,
   passNapoleonDeclaration,
   playCard,
+  processAITurn,
   redealCards,
   setAdjutant,
 } from '@/lib/gameLogic'
@@ -417,8 +417,11 @@ export async function closeTrickResultAction(
     if (updatedGameState.phase === GAME_PHASES.PLAYING) {
       const nextPlayer = getCurrentPlayer(updatedGameState)
       if (nextPlayer?.isAI) {
-        // AIの処理を実行（サーバーサイドで）
-        updatedGameState = await processAIPlayingPhase(updatedGameState)
+        // AIの処理を実行（サーバーサイドで）。
+        // processAIPlayingPhase を直接呼ばず processAITurn を経由するのは、
+        // 未公開の副官の正体を AI から隠すマスク処理がそこにあるため。
+        // 直接呼ぶとこの経路の AI だけが副官を知って打つことになる。
+        updatedGameState = await processAITurn(updatedGameState)
       }
     }
 

--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -13,7 +13,9 @@ import { TurnCue } from '@/components/game/TurnCue'
 import { GameProvider, useGame } from '@/contexts/GameContext'
 import { usePlayerSession } from '@/hooks/useSupabase'
 import {
+  GAME_CONFIG,
   GAME_PHASES,
+  NAPOLEON_RULES,
   PLAYER_ROLES,
   ROLE_LABEL_SEPARATOR,
   SOLO_NAPOLEON_LABELS,
@@ -369,6 +371,10 @@ function GamePageContent() {
     }
 
     const result = calculateGameResult(gameState)
+    const declaredTargetFaceCards =
+      gameState.napoleonDeclaration?.targetTricks ??
+      NAPOLEON_RULES.TARGET_FACE_CARDS
+    const tricksPlayed = gameState.tricks.length
 
     return (
       <div className="min-h-screen bg-gray-100 py-8">
@@ -386,9 +392,21 @@ function GamePageContent() {
                   ? 'Napoleon Team Wins!'
                   : 'Allied Forces Win!'}
               </div>
+              {/* 分母に総絵札数 20 を出すと誤解を招く。
+                  早期終了（scoring.isGameDecided）ではまだ場に出ていない絵札が
+                  残っており、「20 枚中 10 枚」と読めてしまうため。
+                  実際に意味があるのは宣言した目標枚数との比較なので、
+                  目標と消化トリック数を併記する */}
               <p className="text-gray-600">
-                Napoleon team won {result.faceCardsWon} out of 20 face cards
+                Napoleon team won {result.faceCardsWon} face cards (declared{' '}
+                {declaredTargetFaceCards} of {NAPOLEON_RULES.TOTAL_FACE_CARDS})
               </p>
+              {tricksPlayed < GAME_CONFIG.CARDS_PER_PLAYER && (
+                <p className="text-sm text-gray-500 mt-1">
+                  Decided after {tricksPlayed} of {GAME_CONFIG.CARDS_PER_PLAYER}{' '}
+                  tricks — the remaining face cards were never played
+                </p>
+              )}
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">

--- a/src/lib/ai/gameTricks.ts
+++ b/src/lib/ai/gameTricks.ts
@@ -196,11 +196,58 @@ export async function processAlliancePhase(
   return updatedGameState
 }
 
+/**
+ * 手番の AI が出すカードを選ぶ（ゲーム状態は進めない）
+ *
+ * ⚠️ 「思考」と「記帳」を分けるための関数。
+ * AI の思考には副官の正体を伏せたビュー（maskAdjutantIdentityForPlayer）を
+ * 渡すが、そのビューで着手の記帳まで行ってはならない。
+ * playCard → completeTrick → isGameDecided は players[].isAdjutant を読んで
+ * チームを分けるため（scoring.getTeamFaceCardCounts）、マスク済みビューでは
+ * 副官の取ったトリックが連合軍側に計上され、勝敗が誤って早期確定する。
+ * よって呼び出し側は「選択はビュー、playCard は未マスクの真の状態」とすること。
+ */
+export async function selectAICardForCurrentPlayer(
+  gameState: GameState
+): Promise<Card | null> {
+  const currentPlayer = getCurrentPlayer(gameState)
+
+  if (!currentPlayer?.isAI) {
+    return null
+  }
+
+  // AIが出すカードを選択（非同期対応）
+  const cardToPlay = await selectAICard(currentPlayer.hand, gameState)
+
+  if (!cardToPlay) {
+    return null
+  }
+
+  // 機械学習用データ収集（playCard前の状態を記録）
+  if (gameState.phase === GAME_PHASES.PLAYING) {
+    const mlData = extractMLTrainingData(
+      gameState,
+      currentPlayer.id,
+      cardToPlay
+    )
+    if (mlData) {
+      recordGameMove(mlData).catch((error) => {
+        console.error(
+          '[ML Data Collection] Failed to record AI move (non-blocking):',
+          error
+        )
+      })
+    }
+  }
+
+  return cardToPlay
+}
+
 // プレイングフェーズの AI 処理
 export async function processAIPlayingPhase(
   gameState: GameState
 ): Promise<GameState> {
-  let updatedState = { ...gameState }
+  const updatedState = { ...gameState }
 
   // 現在のプレイヤーがAIかチェック
   const currentPlayer = getCurrentPlayer(updatedState)
@@ -209,31 +256,13 @@ export async function processAIPlayingPhase(
     return updatedState
   }
 
-  // AIが出すカードを選択（非同期対応）
-  const cardToPlay = await selectAICard(currentPlayer.hand, updatedState)
+  const cardToPlay = await selectAICardForCurrentPlayer(updatedState)
 
-  if (cardToPlay) {
-    // 機械学習用データ収集（playCard前の状態を記録）
-    if (updatedState.phase === GAME_PHASES.PLAYING) {
-      const mlData = extractMLTrainingData(
-        updatedState,
-        currentPlayer.id,
-        cardToPlay
-      )
-      if (mlData) {
-        recordGameMove(mlData).catch((error) => {
-          console.error(
-            '[ML Data Collection] Failed to record AI move (non-blocking):',
-            error
-          )
-        })
-      }
-    }
-
-    updatedState = playCard(updatedState, currentPlayer.id, cardToPlay.id)
+  if (!cardToPlay) {
+    return updatedState
   }
 
-  return updatedState
+  return playCard(updatedState, currentPlayer.id, cardToPlay.id)
 }
 
 // AIのカード選択ロジック（ハイブリッド戦略版）

--- a/src/lib/game/maskGameState.ts
+++ b/src/lib/game/maskGameState.ts
@@ -120,32 +120,17 @@ export function maskGameStateForPlayer(
   }
 }
 
-/**
- * マスクした副官情報を、未マスクの状態から復元する
+/*
+ * かつてここには `restoreAdjutantIdentity`（マスク済みビューから AI が作った
+ * 次状態に、真の副官情報を戻す関数）があった。削除済み。
  *
- * サーバーサイド AI は「マスク済みビューを入力に取り、そこから次の状態を作って返す」
- * ため（processAIPlayingPhase → playCard）、戻り値をそのまま DB に保存すると
- * 副官フラグが永久に失われる。AI が触らない秘匿フィールドだけを真の値へ戻す。
+ * その復元は「マスク済みビューでゲームを 1 手進める」ことを前提にしていたが、
+ * その前提自体が不具合の原因だった。playCard → completeTrick →
+ * scoring.isGameDecided は players[].isAdjutant でチームを分けるため、
+ * マスク済みビューで進めると副官の取ったトリックが連合軍側に計上され、
+ * 「連合軍が上限超過」で勝敗が誤って早期確定する。役職を後から戻しても
+ * 確定してしまった phase は戻せない。
  *
- * プレイングフェーズ中は `isAdjutant` / `soloNapoleon` は変化しない
- * （設定されるのは ADJUTANT フェーズの setAdjutant のみ）ため、この復元で
- * AI の着手結果を取りこぼすことはない。
- *
- * @param maskedResult マスク済みビューを入力に AI が返した状態
- * @param sourceOfTruth マスク前のゲーム状態
+ * 現在は gameLogic.processAITurn が「思考だけマスク済みビュー、着手は
+ * 未マスクの真の状態」に分離しているため、復元は不要になった。
  */
-export function restoreAdjutantIdentity(
-  maskedResult: GameState,
-  sourceOfTruth: GameState
-): GameState {
-  return {
-    ...maskedResult,
-    soloNapoleon: sourceOfTruth.soloNapoleon,
-    players: maskedResult.players.map((player) => {
-      const truth = sourceOfTruth.players.find((p) => p.id === player.id)
-      return truth === undefined
-        ? player
-        : { ...player, isAdjutant: truth.isAdjutant }
-    }),
-  }
-}

--- a/src/lib/gameLogic.ts
+++ b/src/lib/gameLogic.ts
@@ -1,9 +1,9 @@
-import { processAIPlayingPhase, processAllAIPhases } from '@/lib/ai/gameTricks'
-import { GAME_PHASES } from '@/lib/constants'
 import {
-  maskAdjutantIdentityForPlayer,
-  restoreAdjutantIdentity,
-} from '@/lib/game/maskGameState'
+  processAllAIPhases,
+  selectAICardForCurrentPlayer,
+} from '@/lib/ai/gameTricks'
+import { GAME_PHASES } from '@/lib/constants'
+import { maskAdjutantIdentityForPlayer } from '@/lib/game/maskGameState'
 import { determineWinnerWithSpecialRules } from '@/lib/napoleonCardRules'
 import { isGameDecided } from '@/lib/scoring'
 import type {
@@ -258,6 +258,16 @@ export function setAdjutant(
     players: finalPlayers,
     phase: GAME_PHASES.EXCHANGE,
     napoleonCard: adjutantCard,
+    // 宣言側にも副官指定カードを記録する。
+    // AI ナポレオンは宣言時に adjutantCard を決めるが、人間は宣言後に
+    // AdjutantSelector で選ぶ（setAdjutantAction → ここ）ため、napoleonCard
+    // だけが埋まり napoleonDeclaration.adjutantCard は undefined のままだった。
+    // playCard の revealsAdjutant 判定 (gameLogic.ts) と DeclarationDisplay は
+    // napoleonDeclaration.adjutantCard を見るので、人間ナポレオンでは
+    // 埋め札の副官カードを出しても副官公開フラグが立たなかった。
+    napoleonDeclaration: gameState.napoleonDeclaration
+      ? { ...gameState.napoleonDeclaration, adjutantCard }
+      : gameState.napoleonDeclaration,
     soloNapoleon,
     updatedAt: new Date(),
   }
@@ -328,6 +338,16 @@ export function exchangeCards(
  * サーバーは DB から未マスクの状態を読むため、そのまま渡すと AI だけが
  * 未公開の副官の正体を知って打つことになり、人間との情報量が対等でなくなる
  * （ルール上はナポレオン本人ですら公開まで誰が副官かを知らない）。
+ *
+ * ⚠️ マスクを掛けてよいのは「AI がどのカードを選ぶか」の思考だけで、
+ * 着手の記帳（playCard → completeTrick → isGameDecided）は必ず未マスクの
+ * 真の状態に対して行う。isGameDecided は players[].isAdjutant からチームを
+ * 決める（scoring.getTeamFaceCardCounts）ため、マスク済みビューで完了判定まで
+ * 走らせると副官の取ったトリックが連合軍側に計上され、
+ * 「連合軍が上限超過」の分岐で勝敗が誤って早期確定してしまう。
+ * 実際にそれが起き、5トリック目で終了して結果画面が
+ * 「ナポレオン 10 枚なのに連合軍 0 枚で連合軍の勝ち」という
+ * 内部矛盾した表示になっていた。
  */
 export async function processAITurn(gameState: GameState): Promise<GameState> {
   if (
@@ -336,21 +356,25 @@ export async function processAITurn(gameState: GameState): Promise<GameState> {
     gameState.phase === GAME_PHASES.EXCHANGE
   ) {
     // これらのフェーズでは副官はまだ確定していない（setAdjutant が確定させる）。
-    // ここでマスクすると確定結果を復元時に潰してしまうため、素の状態を渡す。
+    // ここでマスクすると確定結果を潰してしまうため、素の状態を渡す。
     return await processAllAIPhases(gameState)
   }
 
   if (gameState.phase === GAME_PHASES.PLAYING) {
     const currentPlayer = getCurrentPlayer(gameState)
     if (!currentPlayer?.isAI) {
-      return await processAIPlayingPhase(gameState)
+      return gameState
     }
 
+    // 思考はマスク済みビューで
     const aiView = maskAdjutantIdentityForPlayer(gameState, currentPlayer.id)
-    const played = await processAIPlayingPhase(aiView)
+    const cardToPlay = await selectAICardForCurrentPlayer(aiView)
+    if (!cardToPlay) {
+      return gameState
+    }
 
-    // AI はマスク済みビューから次の状態を作るため、保存前に秘匿情報を戻す
-    return restoreAdjutantIdentity(played, gameState)
+    // 記帳・勝敗判定は必ず未マスクの真の状態で
+    return playCard(gameState, currentPlayer.id, cardToPlay.id)
   }
 
   return gameState

--- a/tests/app/actions/gameLogicActions.test.ts
+++ b/tests/app/actions/gameLogicActions.test.ts
@@ -40,17 +40,13 @@ jest.mock('@/lib/gameLogic', () => ({
   getCurrentPlayer: jest.fn(),
   passNapoleonDeclaration: jest.fn(),
   playCard: jest.fn(),
+  processAITurn: jest.fn(),
   redealCards: jest.fn(),
   setAdjutant: jest.fn(),
 }))
 
-jest.mock('@/lib/ai/gameTricks', () => ({
-  processAIPlayingPhase: jest.fn(),
-}))
-
 // Import mocked functions
 import { saveGameStateAction } from '@/app/actions/gameActions'
-import { processAIPlayingPhase } from '@/lib/ai/gameTricks'
 import { GameActionError } from '@/lib/errors/GameActionError'
 import { requireGameState } from '@/lib/game/gameStateRepository'
 import { maskGameStateForPlayer } from '@/lib/game/maskGameState'
@@ -61,6 +57,7 @@ import {
   getCurrentPlayer,
   passNapoleonDeclaration,
   playCard,
+  processAITurn,
   redealCards,
   setAdjutant,
 } from '@/lib/gameLogic'
@@ -306,7 +303,6 @@ describe('Game Logic Actions', () => {
       ;(requireGameState as jest.Mock).mockResolvedValue(gameState)
       ;(exchangeCards as jest.Mock).mockReturnValue(updatedGameState)
       ;(saveGameStateAction as jest.Mock).mockResolvedValue({ success: true })
-      ;(processAIPlayingPhase as jest.Mock).mockResolvedValue(updatedGameState)
 
       const result = await exchangeCardsAction('game-1', 'p1', cards)
 
@@ -326,7 +322,6 @@ describe('Game Logic Actions', () => {
       ;(getCurrentPlayer as jest.Mock).mockReturnValue(currentPlayer)
       ;(playCard as jest.Mock).mockReturnValue(updatedGameState)
       ;(saveGameStateAction as jest.Mock).mockResolvedValue({ success: true })
-      ;(processAIPlayingPhase as jest.Mock).mockResolvedValue(updatedGameState)
 
       const result = await playCardAction('game-1', 'p1', cardId)
 
@@ -343,12 +338,49 @@ describe('Game Logic Actions', () => {
       ;(requireGameState as jest.Mock).mockResolvedValue(gameState)
       ;(closeTrickResult as jest.Mock).mockReturnValue(updatedGameState)
       ;(saveGameStateAction as jest.Mock).mockResolvedValue({ success: true })
-      ;(processAIPlayingPhase as jest.Mock).mockResolvedValue(updatedGameState)
 
       const result = await closeTrickResultAction('game-1', 'p1')
 
       expect(result.success).toBe(true)
       expect(closeTrickResult).toHaveBeenCalledWith(gameState)
+    })
+
+    // AI のターンは必ず processAITurn を経由させる。
+    // processAIPlayingPhase を直接呼ぶと、未公開の副官の正体を AI から隠す
+    // マスク処理（processAITurn の内側にある）を素通りしてしまう。
+    it('advances an AI turn through processAITurn', async () => {
+      const gameState = createGameState(GAME_PHASES.PLAYING)
+      const closedState = { ...gameState }
+      const aiPlayedState = { ...gameState }
+      const aiPlayer = { ...gameState.players[1], isAI: true }
+
+      ;(requireGameState as jest.Mock).mockResolvedValue(gameState)
+      ;(closeTrickResult as jest.Mock).mockReturnValue(closedState)
+      ;(getCurrentPlayer as jest.Mock).mockReturnValue(aiPlayer)
+      ;(processAITurn as jest.Mock).mockResolvedValue(aiPlayedState)
+      ;(saveGameStateAction as jest.Mock).mockResolvedValue({ success: true })
+
+      const result = await closeTrickResultAction('game-1', 'p1')
+
+      expect(result.success).toBe(true)
+      expect(processAITurn).toHaveBeenCalledWith(closedState)
+      expect(saveGameStateAction).toHaveBeenCalledWith(aiPlayedState, 'p1')
+    })
+
+    it('does not run the AI when the next player is human', async () => {
+      const gameState = createGameState(GAME_PHASES.PLAYING)
+      const closedState = { ...gameState }
+      const humanPlayer = { ...gameState.players[0], isAI: false }
+
+      ;(requireGameState as jest.Mock).mockResolvedValue(gameState)
+      ;(closeTrickResult as jest.Mock).mockReturnValue(closedState)
+      ;(getCurrentPlayer as jest.Mock).mockReturnValue(humanPlayer)
+      ;(saveGameStateAction as jest.Mock).mockResolvedValue({ success: true })
+
+      const result = await closeTrickResultAction('game-1', 'p1')
+
+      expect(result.success).toBe(true)
+      expect(processAITurn).not.toHaveBeenCalled()
     })
 
     it('should return error when save fails', async () => {

--- a/tests/lib/game/adjutantDesignationRecord.test.ts
+++ b/tests/lib/game/adjutantDesignationRecord.test.ts
@@ -1,0 +1,132 @@
+/**
+ * 副官指定カードが `napoleonDeclaration.adjutantCard` に必ず記録されることの不変条件
+ *
+ * AI ナポレオンは宣言時に副官カードまで決めるが、人間ナポレオンは宣言後に
+ * AdjutantSelector で選ぶ（setAdjutantAction → gameLogic.setAdjutant）。
+ * そのため人間の局では `napoleonCard` だけが埋まり、
+ * `napoleonDeclaration.adjutantCard` が undefined のまま保存されていた
+ * （実際に壊れたゲーム game_1785552113648_0bkhfcut3 の declaration にも
+ * adjutantCard フィールドが無い）。
+ *
+ * playCard の revealsAdjutant 判定と DeclarationDisplay は
+ * `napoleonDeclaration.adjutantCard` を見るため、未設定だと
+ * 一人ナポレオンで埋め札の副官カードを出しても公開フラグが立たない。
+ */
+
+import { CARD_RANKS, createDeck, GAME_PHASES, SUIT_ENUM } from '@/lib/constants'
+import { playCard, setAdjutant } from '@/lib/gameLogic'
+import type { Card, GameState, Player, Rank, Suit } from '@/types/game'
+
+const DECK = createDeck()
+
+function card(suit: Suit, rank: Rank): Card {
+  const found = DECK.find((c) => c.suit === suit && c.rank === rank)
+  if (!found) {
+    throw new Error(`card not found: ${suit} ${rank}`)
+  }
+  return { ...found }
+}
+
+const NAPOLEON_ID = 'player_1'
+const OTHER_IDS = ['player_2', 'player_3', 'player_4']
+const TRUMP_SUIT: Suit = SUIT_ENUM.HEARTS
+const ADJUTANT_CARD = card(SUIT_ENUM.SPADES, CARD_RANKS.ACE)
+
+function makePlayer(id: string, position: number, hand: Card[]): Player {
+  return {
+    id,
+    name: id,
+    hand,
+    isNapoleon: id === NAPOLEON_ID,
+    isAdjutant: false,
+    position,
+    isAI: id !== NAPOLEON_ID,
+  }
+}
+
+/** ナポレオンが人間の局: 宣言に adjutantCard を含めずに ADJUTANT フェーズへ来る */
+function adjutantPhaseStateWithoutDeclaredCard(options: {
+  buryAdjutantCard: boolean
+}): GameState {
+  const filler = DECK.filter(
+    (c) => c.id !== ADJUTANT_CARD.id && c.suit !== SUIT_ENUM.SPADES
+  )
+
+  const hiddenCards = options.buryAdjutantCard
+    ? [ADJUTANT_CARD, ...filler.slice(0, 3)]
+    : filler.slice(0, 4)
+
+  const holderHand = options.buryAdjutantCard
+    ? filler.slice(4, 8)
+    : [ADJUTANT_CARD, ...filler.slice(4, 7)]
+
+  return {
+    id: 'game_adjutant_record',
+    players: [
+      makePlayer(NAPOLEON_ID, 1, filler.slice(8, 12)),
+      makePlayer(OTHER_IDS[0], 2, holderHand),
+      makePlayer(OTHER_IDS[1], 3, filler.slice(12, 16)),
+      makePlayer(OTHER_IDS[2], 4, filler.slice(16, 20)),
+    ],
+    currentTrick: { id: 'trick_1', cards: [], completed: false },
+    tricks: [],
+    currentPlayerIndex: 0,
+    phase: GAME_PHASES.ADJUTANT,
+    // 人間ナポレオンの宣言には adjutantCard が入らない
+    napoleonDeclaration: {
+      playerId: NAPOLEON_ID,
+      targetTricks: 15,
+      suit: TRUMP_SUIT,
+    },
+    trumpSuit: TRUMP_SUIT,
+    hiddenCards,
+    passedPlayers: [],
+    declarationTurn: 0,
+    needsRedeal: false,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }
+}
+
+describe('setAdjutant records the designation card on the declaration', () => {
+  it('fills napoleonDeclaration.adjutantCard when the declaration had none', () => {
+    const state = adjutantPhaseStateWithoutDeclaredCard({
+      buryAdjutantCard: false,
+    })
+    expect(state.napoleonDeclaration?.adjutantCard).toBeUndefined()
+
+    const result = setAdjutant(state, ADJUTANT_CARD)
+
+    expect(result.napoleonDeclaration?.adjutantCard?.id).toBe(ADJUTANT_CARD.id)
+  })
+
+  it('keeps napoleonCard and napoleonDeclaration.adjutantCard in sync', () => {
+    const state = adjutantPhaseStateWithoutDeclaredCard({
+      buryAdjutantCard: false,
+    })
+
+    const result = setAdjutant(state, ADJUTANT_CARD)
+
+    expect(result.napoleonCard?.id).toBe(
+      result.napoleonDeclaration?.adjutantCard?.id
+    )
+  })
+
+  it('lets a human Napoleon reveal a buried adjutant card when playing it', () => {
+    const adjutantPhase = adjutantPhaseStateWithoutDeclaredCard({
+      buryAdjutantCard: true,
+    })
+    const afterAdjutant = setAdjutant(adjutantPhase, ADJUTANT_CARD)
+
+    // 交換フェーズを飛ばして、埋め札を受け取ったナポレオンの手番から打つ
+    const playing: GameState = {
+      ...afterAdjutant,
+      phase: GAME_PHASES.PLAYING,
+      currentPlayerIndex: 0,
+    }
+
+    const played = playCard(playing, NAPOLEON_ID, ADJUTANT_CARD.id)
+
+    expect(played.currentTrick.cards[0].revealsAdjutant).toBe(true)
+  })
+})

--- a/tests/lib/game/aiAdjutantVisibility.test.ts
+++ b/tests/lib/game/aiAdjutantVisibility.test.ts
@@ -5,17 +5,24 @@
  * 「AI だけが人間より多くを知って打つ」状態になる。
  * ルール上は副官指定カードが場に出るまで、ナポレオン本人ですら
  * 誰が副官かを知らない（docs/game-logic/NAPOLEON_RULES.md）。
+ *
+ * ⚠️ マスクしてよいのは「どのカードを選ぶか」の思考だけ。着手の記帳は
+ * 未マスクの真の状態で行う（gameLogic.processAITurn のコメント参照）。
+ * ここではその境界も併せて固定する。
  */
 
 import { GAME_PHASES } from '@/lib/constants'
 import type { Card, GameState, PlayedCard, Player, Trick } from '@/types/game'
 
 jest.mock('@/lib/ai/gameTricks', () => ({
-  processAIPlayingPhase: jest.fn(),
+  selectAICardForCurrentPlayer: jest.fn(),
   processAllAIPhases: jest.fn(),
 }))
 
-import { processAIPlayingPhase, processAllAIPhases } from '@/lib/ai/gameTricks'
+import {
+  processAllAIPhases,
+  selectAICardForCurrentPlayer,
+} from '@/lib/ai/gameTricks'
 import { processAITurn } from '@/lib/gameLogic'
 
 const createCard = (id: string, rank: Card['rank']): Card => ({
@@ -81,15 +88,15 @@ const createRevealedTrick = (): Trick => {
   }
 }
 
-/** processAIPlayingPhase が受け取った状態（AI 評価層に入る状態） */
+/** AI の思考（カード選択）へ渡された状態 */
 const stateGivenToAI = (): GameState =>
-  (processAIPlayingPhase as jest.Mock).mock.calls[0][0] as GameState
+  (selectAICardForCurrentPlayer as jest.Mock).mock.calls[0][0] as GameState
 
 beforeEach(() => {
   jest.clearAllMocks()
-  // AI は受け取った状態をそのまま返す（着手の中身はここでの関心事ではない）
-  ;(processAIPlayingPhase as jest.Mock).mockImplementation(
-    async (state: GameState) => state
+  // AI は手番プレイヤーの1枚目を選ぶ（どのカードかはここでの関心事ではない）
+  ;(selectAICardForCurrentPlayer as jest.Mock).mockImplementation(
+    async (state: GameState) => state.players[state.currentPlayerIndex].hand[0]
   )
   ;(processAllAIPhases as jest.Mock).mockImplementation(
     async (state: GameState) => state
@@ -201,12 +208,12 @@ describe('processAITurn - adjutant identity hidden from AI', () => {
       await processAITurn(state)
 
       expect(processAllAIPhases).toHaveBeenCalledWith(state)
-      expect(processAIPlayingPhase).not.toHaveBeenCalled()
+      expect(selectAICardForCurrentPlayer).not.toHaveBeenCalled()
     })
   })
 
-  describe('the returned state (persisted to the DB) keeps the truth', () => {
-    it('restores isAdjutant on the state processAITurn returns', async () => {
+  describe('the move itself is applied to the unmasked state', () => {
+    it('keeps isAdjutant true on the state processAITurn returns', async () => {
       const result = await processAITurn(createPlayingState())
 
       expect(
@@ -214,7 +221,7 @@ describe('processAITurn - adjutant identity hidden from AI', () => {
       ).toBe(true)
     })
 
-    it('restores soloNapoleon on the state processAITurn returns', async () => {
+    it('keeps soloNapoleon on the state processAITurn returns', async () => {
       const result = await processAITurn(
         createPlayingState({ soloNapoleon: true })
       )
@@ -222,35 +229,12 @@ describe('processAITurn - adjutant identity hidden from AI', () => {
       expect(result.soloNapoleon).toBe(true)
     })
 
-    it('keeps the AI move made on the masked view', async () => {
-      // AI が masked view から次の状態を作るのを模す（カードを1枚出す）
-      ;(processAIPlayingPhase as jest.Mock).mockImplementation(
-        async (state: GameState): Promise<GameState> => ({
-          ...state,
-          currentTrick: {
-            ...state.currentTrick,
-            cards: [
-              {
-                card: state.players[0].hand[0],
-                playerId: state.players[0].id,
-                order: 0,
-              },
-            ],
-          },
-          players: state.players.map((p, index) =>
-            index === 0 ? { ...p, hand: p.hand.slice(1) } : p
-          ),
-        })
-      )
-
+    it('applies the card the AI chose', async () => {
       const result = await processAITurn(createPlayingState())
 
       expect(result.currentTrick.cards).toHaveLength(1)
+      expect(result.currentTrick.cards[0].card.id).toBe('ai-thinker-c1')
       expect(result.players[0].hand.map((c) => c.id)).toEqual(['ai-thinker-c2'])
-      // 復元しても副官情報は正しい
-      expect(
-        result.players.find((p) => p.id === 'ai-adjutant')?.isAdjutant
-      ).toBe(true)
     })
 
     it('does not mutate the original (server side) state', async () => {
@@ -261,15 +245,17 @@ describe('processAITurn - adjutant identity hidden from AI', () => {
         original.players.find((p) => p.id === 'ai-adjutant')?.isAdjutant
       ).toBe(true)
       expect(original.soloNapoleon).toBe(false)
+      expect(original.currentTrick.cards).toHaveLength(0)
     })
   })
 
   describe('human turn', () => {
-    it('does not mask when the current player is human', async () => {
+    it('does not run the AI at all when the current player is human', async () => {
       const state = createPlayingState({ currentPlayerIndex: 3 })
-      await processAITurn(state)
+      const result = await processAITurn(state)
 
-      expect(processAIPlayingPhase).toHaveBeenCalledWith(state)
+      expect(selectAICardForCurrentPlayer).not.toHaveBeenCalled()
+      expect(result).toBe(state)
     })
   })
 })

--- a/tests/lib/game/gameEndDecisionIntegrity.test.ts
+++ b/tests/lib/game/gameEndDecisionIntegrity.test.ts
@@ -1,0 +1,271 @@
+/**
+ * 「勝敗の早期確定は、未マスクの真の役職で判定されなければならない」不変条件
+ *
+ * 背景（実際に起きた不具合）:
+ *   processAITurn は AI の思考へ「未公開の副官の正体を伏せたビュー」を渡す。
+ *   かつてはそのビューのままゲームを1手進めていたため、
+ *   playCard → completeTrick → scoring.isGameDecided が
+ *   players[].isAdjutant からチームを分ける際に副官を連合軍だと誤認し、
+ *   副官が取ったトリックの絵札を連合軍側へ計上していた。
+ *   その結果「連合軍が上限超過」の分岐が誤って発火し、5トリック目でゲームが
+ *   終了。役職は保存前に真の値へ戻されるため、DB には
+ *   「isAdjutant=true / tricks=5 / decided=false なのに phase=finished」という
+ *   内部矛盾した状態が残り、結果画面は
+ *   「ナポレオン 10 枚・連合軍 0 枚なのに連合軍の勝ち」と表示した。
+ *
+ * ここでは実際に壊れた局面を固定し、加えて実装の内部挙動ではなく
+ * 「AI 経由で進めた状態 == 真の状態へ直接着手した状態」という不変条件で守る。
+ */
+
+import {
+  CARD_RANKS,
+  createDeck,
+  GAME_CONFIG,
+  GAME_PHASES,
+  SUIT_ENUM,
+} from '@/lib/constants'
+import type { Card, GameState, Player, Rank, Suit, Trick } from '@/types/game'
+
+jest.mock('@/lib/ai/gameTricks', () => ({
+  selectAICardForCurrentPlayer: jest.fn(),
+  processAllAIPhases: jest.fn(),
+}))
+
+import { selectAICardForCurrentPlayer } from '@/lib/ai/gameTricks'
+import { playCard, processAITurn } from '@/lib/gameLogic'
+import {
+  calculateGameResult,
+  getPlayerFaceCardCount,
+  getTeamFaceCardCounts,
+  isGameDecided,
+} from '@/lib/scoring'
+
+const DECK = createDeck()
+
+/** 実カードを id ごと再現する（createDeck と同じ id 体系を使う） */
+function card(suit: Suit, rank: Rank): Card {
+  const found = DECK.find((c) => c.suit === suit && c.rank === rank)
+  if (!found) {
+    throw new Error(`card not found: ${suit} ${rank}`)
+  }
+  return { ...found }
+}
+
+// 実際に壊れたゲーム（Supabase dev / games.id = game_1785552113648_0bkhfcut3）の登場人物
+const NAPOLEON_ID = 'player_0801gkr22'
+const ALLY_1_ID = 'player_zrkq75lp0'
+const ALLY_2_ID = 'player_70mhmo0bq'
+const ADJUTANT_ID = 'player_5t0qwtzzd'
+
+const DECLARED_TARGET = 15
+const TRUMP_SUIT: Suit = SUIT_ENUM.HEARTS
+
+/** 副官指定カード = マイティ（♠A）。ユーザー証言「副官がマイティーを出した」 */
+const ADJUTANT_DESIGNATION_CARD = card(SUIT_ENUM.SPADES, CARD_RANKS.ACE)
+
+function makePlayer(
+  id: string,
+  position: number,
+  hand: Card[],
+  overrides: Partial<Player> = {}
+): Player {
+  return {
+    id,
+    name: id,
+    hand,
+    isNapoleon: false,
+    isAdjutant: false,
+    position,
+    isAI: true,
+    ...overrides,
+  }
+}
+
+/**
+ * 完了済みトリックを組む。
+ * 集計に効くのは winnerPlayerId と cards の絵札だけなので、
+ * 着手者は循環で割り当てる（実ゲームの席順とは一致させない）。
+ */
+function completedTrick(id: string, winnerId: string, cards: Card[]): Trick {
+  const seats = [NAPOLEON_ID, ALLY_1_ID, ALLY_2_ID, ADJUTANT_ID]
+  return {
+    id,
+    cards: cards.map((c, order) => ({
+      card: c,
+      playerId: seats[order],
+      order,
+    })),
+    winnerPlayerId: winnerId,
+    completed: true,
+    leadingSuit: cards[0].suit,
+  }
+}
+
+/** DB に残っていた 4 トリック分（副官 6 枚 / ナポレオン 2 枚 / 連合軍 0 枚） */
+function completedTricksFromIncident(): Trick[] {
+  return [
+    completedTrick('trick_1', ADJUTANT_ID, [
+      card(SUIT_ENUM.SPADES, CARD_RANKS.JACK),
+      card(SUIT_ENUM.SPADES, CARD_RANKS.FIVE),
+      card(SUIT_ENUM.SPADES, CARD_RANKS.TWO),
+      card(SUIT_ENUM.SPADES, CARD_RANKS.SIX),
+    ]),
+    completedTrick('trick_2', ADJUTANT_ID, [
+      card(SUIT_ENUM.DIAMONDS, CARD_RANKS.JACK),
+      card(SUIT_ENUM.DIAMONDS, CARD_RANKS.TEN),
+      card(SUIT_ENUM.DIAMONDS, CARD_RANKS.KING),
+      card(SUIT_ENUM.DIAMONDS, CARD_RANKS.TWO),
+    ]),
+    completedTrick('trick_3', NAPOLEON_ID, [
+      card(SUIT_ENUM.CLUBS, CARD_RANKS.KING),
+      card(SUIT_ENUM.CLUBS, CARD_RANKS.TWO),
+      card(SUIT_ENUM.CLUBS, CARD_RANKS.ACE),
+      card(SUIT_ENUM.CLUBS, CARD_RANKS.SIX),
+    ]),
+    completedTrick('trick_4', ADJUTANT_ID, [
+      card(SUIT_ENUM.HEARTS, CARD_RANKS.EIGHT),
+      card(SUIT_ENUM.HEARTS, CARD_RANKS.KING),
+      card(SUIT_ENUM.HEARTS, CARD_RANKS.NINE),
+      card(SUIT_ENUM.HEARTS, CARD_RANKS.ACE),
+    ]),
+  ]
+}
+
+/** 4枚目を出す連合軍 AI が持っているカード */
+const FOURTH_CARD = card(SUIT_ENUM.SPADES, CARD_RANKS.TEN)
+
+/**
+ * 第5トリックの途中（副官がマイティでリードし、あと1枚で完成）。
+ * 手番は連合軍 AI（= 副官でも人間でもない）で、ここが不具合の発火点だった。
+ */
+function incidentState(): GameState {
+  const currentTrick: Trick = {
+    id: 'trick_5',
+    cards: [
+      {
+        card: ADJUTANT_DESIGNATION_CARD,
+        playerId: ADJUTANT_ID,
+        order: 0,
+      },
+      {
+        card: card(SUIT_ENUM.CLUBS, CARD_RANKS.FIVE),
+        playerId: NAPOLEON_ID,
+        order: 1,
+      },
+      {
+        card: card(SUIT_ENUM.SPADES, CARD_RANKS.SEVEN),
+        playerId: ALLY_1_ID,
+        order: 2,
+      },
+    ],
+    completed: false,
+    leadingSuit: SUIT_ENUM.SPADES,
+  }
+
+  return {
+    id: 'game_1785552113648_0bkhfcut3',
+    players: [
+      makePlayer(NAPOLEON_ID, 1, [card(SUIT_ENUM.CLUBS, CARD_RANKS.THREE)], {
+        isNapoleon: true,
+        isAI: false,
+      }),
+      makePlayer(ALLY_1_ID, 2, [card(SUIT_ENUM.CLUBS, CARD_RANKS.FOUR)]),
+      makePlayer(ALLY_2_ID, 3, [
+        FOURTH_CARD,
+        card(SUIT_ENUM.HEARTS, CARD_RANKS.THREE),
+      ]),
+      makePlayer(ADJUTANT_ID, 4, [card(SUIT_ENUM.CLUBS, CARD_RANKS.SEVEN)], {
+        isAdjutant: true,
+      }),
+    ],
+    currentTrick,
+    tricks: completedTricksFromIncident(),
+    currentPlayerIndex: 2, // ALLY_2（AI）が4枚目を出す
+    phase: GAME_PHASES.PLAYING,
+    napoleonDeclaration: {
+      playerId: NAPOLEON_ID,
+      targetTricks: DECLARED_TARGET,
+      suit: TRUMP_SUIT,
+    },
+    napoleonCard: ADJUTANT_DESIGNATION_CARD,
+    soloNapoleon: false,
+    leadingSuit: SUIT_ENUM.SPADES,
+    trumpSuit: TRUMP_SUIT,
+    hiddenCards: [],
+    passedPlayers: [],
+    declarationTurn: 0,
+    needsRedeal: false,
+    createdAt: new Date(0),
+    updatedAt: new Date(0),
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(selectAICardForCurrentPlayer as jest.Mock).mockImplementation(
+    async () => FOURTH_CARD
+  )
+})
+
+describe('early game-end decision must use the true adjutant identity', () => {
+  it('the incident position is not decided yet (napoleon 10 / allied 0 / target 15)', () => {
+    const state = incidentState()
+    const afterFourthCard = playCard(state, ALLY_2_ID, FOURTH_CARD.id)
+
+    expect(afterFourthCard.tricks).toHaveLength(5)
+    expect(getTeamFaceCardCounts(afterFourthCard)).toEqual({
+      napoleonTeam: 10,
+      citizenTeam: 0,
+    })
+    expect(isGameDecided(afterFourthCard).decided).toBe(false)
+  })
+
+  it('does not finish the game when an allied AI completes the trick the adjutant won', async () => {
+    const result = await processAITurn(incidentState())
+
+    expect(result.phase).toBe(GAME_PHASES.PLAYING)
+    expect(result.tricks).toHaveLength(5)
+    expect(result.tricks[4].winnerPlayerId).toBe(ADJUTANT_ID)
+  })
+
+  it('reproduces the reported per-player tally but without ending the game', async () => {
+    const result = await processAITurn(incidentState())
+
+    // 報告された画面と同じ内訳（2 / 0 / 0 / 8）が出る局面であること
+    expect(
+      result.players.map((p) => getPlayerFaceCardCount(result, p.id))
+    ).toEqual([2, 0, 0, 8])
+    // それでもゲームは終わっていない
+    expect(result.phase).not.toBe(GAME_PHASES.FINISHED)
+  })
+
+  it('advances exactly like playing the same card on the unmasked state', async () => {
+    const viaAI = await processAITurn(incidentState())
+    const direct = playCard(incidentState(), ALLY_2_ID, FOURTH_CARD.id)
+
+    expect(viaAI.phase).toBe(direct.phase)
+    expect(viaAI.tricks).toHaveLength(direct.tricks.length)
+    expect(getTeamFaceCardCounts(viaAI)).toEqual(getTeamFaceCardCounts(direct))
+    expect(viaAI.players.map((p) => p.isAdjutant)).toEqual(
+      direct.players.map((p) => p.isAdjutant)
+    )
+  })
+
+  it('never leaves a finished state that the result screen contradicts', async () => {
+    const result = await processAITurn(incidentState())
+
+    // 不変条件: 12トリック未満で FINISHED なら、必ず勝敗が確定していること。
+    // かつ、その確定内容は結果画面の計算（calculateGameResult）と一致すること。
+    if (
+      result.phase === GAME_PHASES.FINISHED &&
+      result.tricks.length < GAME_CONFIG.CARDS_PER_PLAYER
+    ) {
+      const decision = isGameDecided(result)
+      expect(decision.decided).toBe(true)
+      expect(decision.napoleonWon).toBe(calculateGameResult(result).napoleonWon)
+    }
+
+    // この局面ではそもそも終了してはいけない
+    expect(result.phase).toBe(GAME_PHASES.PLAYING)
+  })
+})

--- a/tests/lib/game/maskGameState.test.ts
+++ b/tests/lib/game/maskGameState.test.ts
@@ -6,7 +6,6 @@ import { GAME_PHASES, MASKED_CARD } from '@/lib/constants'
 import {
   maskAdjutantIdentityForPlayer,
   maskGameStateForPlayer,
-  restoreAdjutantIdentity,
 } from '@/lib/game/maskGameState'
 import type { Card, GameState, PlayedCard, Player, Trick } from '@/types/game'
 
@@ -301,53 +300,5 @@ describe('maskAdjutantIdentityForPlayer', () => {
       true
     )
     expect(original.soloNapoleon).toBe(true)
-  })
-})
-
-describe('restoreAdjutantIdentity', () => {
-  it('restores isAdjutant and soloNapoleon from the unmasked state', () => {
-    const truth = createAdjutantGameState({ soloNapoleon: true })
-    const view = maskAdjutantIdentityForPlayer(truth, 'me')
-
-    const restored = restoreAdjutantIdentity(view, truth)
-
-    expect(restored.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
-      true
-    )
-    expect(restored.soloNapoleon).toBe(true)
-  })
-
-  it('keeps the changes the caller made on the masked view', () => {
-    const truth = createAdjutantGameState()
-    const view = maskAdjutantIdentityForPlayer(truth, 'me')
-    const played: GameState = {
-      ...view,
-      players: view.players.map((player) => ({
-        ...player,
-        hand: player.hand.slice(1),
-      })),
-    }
-
-    const restored = restoreAdjutantIdentity(played, truth)
-
-    expect(restored.players.map((p) => p.hand.length)).toEqual([1, 1])
-    expect(restored.players.find((p) => p.id === 'other')?.isAdjutant).toBe(
-      true
-    )
-  })
-
-  it('leaves unknown players untouched', () => {
-    const truth = createAdjutantGameState()
-    const view = maskAdjutantIdentityForPlayer(truth, 'me')
-    const withNewcomer: GameState = {
-      ...view,
-      players: [...view.players, createPlayer('newcomer', [])],
-    }
-
-    const restored = restoreAdjutantIdentity(withNewcomer, truth)
-
-    expect(restored.players.find((p) => p.id === 'newcomer')?.isAdjutant).toBe(
-      false
-    )
   })
 })


### PR DESCRIPTION
## これは #506 のリグレッションです

実際の対局（`game_1785552113648_0bkhfcut3`）で、**副官がマイティを出した 5 トリック目でゲームが打ち切られ**、連合軍の勝利と表示されました。全員の手札が 7 枚残ったままです。

結果画面の表示:
```
Allied Forces Win!
Napoleon team won 10 out of 20 face cards
  You (Napoleon) 2 / AI 1 (Allied) 0 / AI 2 (Allied) 0 / AI 3 (Adjutant) 8
```

絵札 20 枚のうち除外されるのは捨て札 4 枚までなので、ナポレオンチームが 10 枚なら連合軍は最低 6 枚あるはずで、0 + 0 は算術的に成立しません。

## DB の state は内部矛盾していた

```
phase: finished / tricks: 5 / 全員 hand=7
declaration: {suit: hearts, targetTricks: 15}   ← adjutantCard が無い
player_5t0qwtzzd: isAdjutant=true
  #1 winner=adjutant [♠J ♠5 ♠2 ♠6] face=1
  #2 winner=adjutant [♦J ♦10 ♦K ♦2] face=3
  #3 winner=napoleon [♣K ♣2 ♣A ♣6] face=2
  #4 winner=adjutant [♥8 ♥K ♥9 ♥A] face=2
  #5 winner=adjutant [♠A ♣5 ♠7 ♠10] face=2   ← 副官がマイティでリード
```

保存されている flags で `isGameDecided` を計算し直すと **どの分岐でも decided になりません**（ナポレオンチーム 10 / 連合軍 0 / 宣言 15）。にもかかわらず `phase=finished`。

## 原因

`gameLogic.ts` の `processAITurn` が、**AI に副官を見せないためのマスク済みビューをそのまま `processAIPlayingPhase` に渡していました**。この関数は `playCard` → `completeTrick` → `isGameDecided` まで進めるため、**終了判定が「副官がいない」前提で実行されます**。

`scoring.ts` の `getTeamFaceCardCounts` は `players.find(p => p.isAdjutant)` でチームを決めるので、マスク下では副官の取ったトリックが連合軍側に計上されます。事故局面では:

| | 真の値 | マスク下 |
|---|---|---|
| ナポレオンチーム | 10 | 2 |
| 連合軍 | 0 | **8** |

宣言 15 に対する連合軍の上限は `20 - 15 = 5`。マスク下の 8 がこれを超え、`decided: true, napoleonWon: false` で終了しました。

`restoreAdjutantIdentity` は判定後に `isAdjutant` を戻していましたが、**`phase` は戻せません**。これが「`isAdjutant=true`・`tricks=5`・`isGameDecided` は false・なのに `phase=finished`」という矛盾の正体です。

**なぜ 5 トリック目だったか**: `checkAdjutantRevealed` は*完了した*トリックしか見ないため、マイティが `currentTrick` にある間はまだ副官がマスクされたままでした。5 トリック目の 4 枚目を打ったのは副官でも人間でもない AI で、マスク経路を通りました。

**修正前のコードで事故局面を再生すると、DB の値をそのまま再現します**（`phase: finished / tricks: 5 / 2,0,0,8 / napoleonWon: false`）。修正後は `phase: playing` のまま続行します。

## 修正

マスクは「AI が何を出すか考える」ためだけに使い、**着手そのものは真の state に適用**します。

- `gameTricks.ts` に `selectAICardForCurrentPlayer` を切り出し（state を進めずに札だけ選ぶ）
- `processAITurn` はマスク済みビューで札を選び、`playCard` は未マスクの state に適用
- 往復が不要になったので `restoreAdjutantIdentity` を削除（コメントで理由を残置）

**あわせて #506 のもう一つの穴も塞ぎます**: `closeTrickResultAction` は `processAIPlayingPhase` を直接呼んでおり、そちらでは AI が副官を見えたままでした。集計は正しかったので今回の事故の原因ではありませんが、#506 の意図が効いていませんでした。

## 副次的な修正 2 件

**`setAdjutant` が `napoleonDeclaration.adjutantCard` を記録していなかった。**人間のナポレオンは宣言後に副官カードを選ぶため `undefined` のままでした。`checkAdjutantRevealed` は `napoleonCard` を読むので公開自体は動いていましたが、`playCard` の `revealsAdjutant` 分岐と `DeclarationDisplay` はこちらを読むため、一人ナポレオンが埋め札の副官カードを出しても公開フラグが立ちませんでした。

**結果画面の "out of 20"。**早期終了では未プレイの絵札が残るため誤解を招きます。消化トリック数と宣言数を併記するようにしました。

## テスト

- **新規** `gameEndDecisionIntegrity.test.ts`（5 件）— 事故局面を固定。`isGameDecided` が false であること、終了しないこと、2/0/0/8 の集計、および実装非依存の不変条件 2 つ（「`processAITurn` は同じ札を未マスク state に打つのと同一に進む」「12 トリック未満の FINISHED は decided かつ `calculateGameResult` と一致する」）
- **新規** `adjutantDesignationRecord.test.ts`（3 件）
- `aiAdjutantVisibility.test.ts` を新しい継ぎ目に合わせて更新（マスクの意図は同じ）
- `gameLogicActions.test.ts` に `closeTrickResultAction` の AI 経路のテストを追加（`getCurrentPlayer` が未モックで黙って通っていた）

`63 suites / 841 tests` → **`65 suites / 848 tests`**、全通過。`pnpm ci-check` exit 0。**修正を外すと新規テストの 5 件中 4 件が落ちる**ことを確認済みです。

## 未対応

- **`checkAdjutantRevealed` が `currentTrick` を見ない**点は残しました。副官が指定カードを出しても、そのトリックが完了するまで UI/AI には隠れたままです。今回の事故では「決定的なトリックの間マスクが外れなかった」という形で寄与しましたが、修正後は原因ではなくなっています。公開タイミングの変更は UI 挙動に波及するため別課題とします
- **既に壊れた DB 行の修復はしていません**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- ea5ca49 fix(game): マスク済み state で終了判定してゲームが誤って終わる問題を直す

## 📁 Files Changed

**Total files changed: 10**

- 🔧 **Source Code**: 5 files
- 🧪 **Tests**: 5 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/lib/game/adjutantDesignationRecord.test.ts`
- `tests/lib/game/gameEndDecisionIntegrity.test.ts`
- `tests/app/actions/gameLogicActions.test.ts`
- `tests/lib/game/aiAdjutantVisibility.test.ts`
- `tests/lib/game/maskGameState.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/app/actions/gameLogicActions.ts`
- `src/app/game/[gameId]/page.tsx`
- `src/lib/ai/gameTricks.ts`
- `src/lib/game/maskGameState.ts`
- `src/lib/gameLogic.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added
- 🎮 **Game Logic** - Core game functionality updated
- 💄 **UI/UX** - User interface improvements

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/face-card-tally
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*