### PR TITLE
fix(game): 競り中に副官の指定カードが他プレイヤーへ漏れるのを止める

### DIFF
--- a/src/components/game/GameStatus.tsx
+++ b/src/components/game/GameStatus.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import {
+  BIDDING_LABELS,
   GAME_PHASES,
   NAPOLEON_RULES,
   PLAYER_ROLES,
@@ -31,6 +32,12 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
   const adjutantPlayer = gameState.players.find((p) => p.isAdjutant)
   // マスク済みなので、閲覧者に公開してよい場合のみ true になる
   const soloNapoleon = isSoloNapoleon(gameState)
+
+  // 競りの最中。declareNapoleon は宣言のたびに isNapoleon / trumpSuit を
+  // 立てるため、この時点でも napoleonPlayer は取れてしまうが、それは
+  // 「現在の最高提示者」でしかない。まだ誰でも上乗せしてナポレオンを
+  // 奪えるので、確定したチーム・役職として見せてはいけない
+  const isBidding = gameState.phase === GAME_PHASES.NAPOLEON
 
   const currentPlayerStats = currentPlayerId
     ? getPlayerStats(gameState, currentPlayerId)
@@ -91,7 +98,7 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
       {gameState.napoleonDeclaration && (
         <div className="border-b pb-2 md:pb-3">
           <h4 className="font-semibold text-sm md:text-base text-gray-800 mb-1 md:mb-2">
-            Napoleon Declaration
+            {isBidding ? BIDDING_LABELS.SECTION_TITLE : 'Napoleon Declaration'}
           </h4>
           <div className="bg-yellow-50 border border-yellow-200 p-2 md:p-3 rounded-lg">
             <div className="flex items-center justify-center gap-2 md:gap-4 text-sm">
@@ -114,10 +121,18 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
             </div>
             <div className="text-center text-xs md:text-sm text-yellow-700 mt-1 md:mt-2">
               <span className="font-semibold">
-                Declared by: {napoleonPlayer?.name}
+                {isBidding ? BIDDING_LABELS.BID_BY : 'Declared by:'}{' '}
+                {napoleonPlayer?.name}
               </span>
             </div>
-            {/* 副官「指定カード」は宣言時に全員へ告げられる公開情報 */}
+            {isBidding && (
+              <div className="text-center text-[0.6rem] md:text-xs text-gray-600 mt-1">
+                {BIDDING_LABELS.UNDECIDED_NOTE}
+              </div>
+            )}
+            {/* 副官「指定カード」は宣言が確定したあとの公開情報。
+                競りの最中は maskGameStateForPlayer が宣言者以外へ渡さないため、
+                ここは undefined になり表示されない */}
             {gameState.napoleonCard && (
               <div className="flex justify-center mt-2 pt-2 border-t border-yellow-200">
                 <AdjutantCardBadge
@@ -131,8 +146,11 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
         </div>
       )}
 
-      {/* チーム構成 - 副官は判明した場合のみ表示 */}
-      {napoleonPlayer && (
+      {/* チーム構成 - 副官は判明した場合のみ表示。
+          競りの最中は「Napoleon / Adjutant / Allied Forces」がまだ確定して
+          いないので出さない（上乗せすれば閲覧者自身がナポレオンになりうる）。
+          最高提示者は上の Current Highest Bid ブロックが示している */}
+      {napoleonPlayer && !isBidding && (
         <div className="border-b pb-3">
           <h4 className="font-semibold text-gray-800 mb-2">Teams</h4>
           <div className="space-y-2 text-sm">
@@ -314,12 +332,17 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
         <div className="border-b pb-3">
           <h4 className="font-semibold text-gray-800 mb-2">Your Stats</h4>
           <div className="space-y-1 text-sm">
-            <div className="flex justify-between">
-              <span>Role:</span>
-              <span className="font-medium">
-                {getRoleDisplay(currentPlayerStats.role)}
-              </span>
-            </div>
+            {/* 競り中の role は「今のところナポレオンではない」だけの暫定値。
+                Allied Forces と断定表示すると、上乗せでナポレオンになれる
+                ことが伝わらないので出さない */}
+            {!isBidding && (
+              <div className="flex justify-between">
+                <span>Role:</span>
+                <span className="font-medium">
+                  {getRoleDisplay(currentPlayerStats.role)}
+                </span>
+              </div>
+            )}
             <div className="flex justify-between">
               <span>Face Cards Won:</span>
               <span>{currentPlayerStats.faceCardsWon}</span>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -180,6 +180,15 @@ export const SOLO_NAPOLEON_LABELS = {
 // 秘匿情報である「誰が副官か」と取り違えられないよう、必ず Card を明記する
 export const ADJUTANT_CARD_LABEL = `${PLAYER_ROLES.ADJUTANT} Card`
 
+// 競り（GAME_PHASES.NAPOLEON）中の表示ラベル。
+// この時点の宣言はまだ上乗せされうる暫定値で、ナポレオン・副官・連合軍の
+// いずれも確定していない。確定した宣言・チームと同じ見た目にしないこと
+export const BIDDING_LABELS = {
+  SECTION_TITLE: 'Current Highest Bid',
+  BID_BY: 'Highest bid by:',
+  UNDECIDED_NOTE: 'Bidding in progress - teams are not decided yet',
+} as const
+
 export const GAME_CONFIG = {
   PLAYERS_COUNT: 4,
   CARDS_PER_PLAYER: 12, // 52枚（Joker除外）から4人に12枚ずつ配って残り4枚

--- a/src/lib/game/maskGameState.ts
+++ b/src/lib/game/maskGameState.ts
@@ -13,13 +13,17 @@
  * 一人ナポレオン（`soloNapoleon`）も同じ理由で伏せる。ナポレオン本人だけは
  * 指定カードが自分の手札に入るため常に知っている。
  *
+ * さらに競り（`GAME_PHASES.NAPOLEON`）の最中は、副官「指定カード」そのもの
+ * （`napoleonDeclaration.adjutantCard` / `napoleonCard`）も宣言者以外へ渡さない。
+ * 詳細は maskBiddingDeclarationForPlayer のコメントを参照。
+ *
  * AI の思考はサーバーサイド（processAITurn / processAIPlayingPhase）で行われ、
  * DB から読み直した未マスクの状態を使う。ただし副官の正体だけは AI にも
  * 見せてはいけない（人間より多くを知って打つのはフェアネス違反）ため、
  * processAITurn が maskAdjutantIdentityForPlayer で手番 AI 視点のビューを作る。
  */
 
-import { MASKED_CARD } from '@/lib/constants'
+import { GAME_PHASES, MASKED_CARD } from '@/lib/constants'
 import type { Card, GameState } from '@/types/game'
 import { isAdjutantIdentityPublic } from '@/utils/gameUtils'
 
@@ -85,6 +89,52 @@ export function maskAdjutantIdentityForPlayer(
 }
 
 /**
+ * 競り（ナポレオン宣言フェーズ）中の「呼ぶ札」を宣言者以外から伏せる
+ *
+ * AI は宣言と同時に副官指定カードを決める（ai/napoleon.ts の
+ * `selectAdjutantCard` → `declaration.adjutantCard`）のに対し、人間は宣言後の
+ * AdjutantSelector で選ぶ（NapoleonSelector に指定カードの入力は無い）。
+ * この非対称のせいで、AI が宣言した瞬間に呼ぶ札が
+ * `napoleonDeclaration.adjutantCard` と `napoleonCard`（declareNapoleon が
+ * 互換用に複製する）へ載り、まだ上乗せできる人間へそのまま届いていた。
+ * 「♠A が呼ばれている＝自分が副官になれる／なれない」と分かった状態で
+ * 競りを続けられるのは明確なアドバンテージになる。
+ *
+ * 隠すのは競りの最中だけでよい。ルール上、呼ぶ札は宣言が確定したあとは
+ * 全員への公開情報（docs/game-logic/NAPOLEON_RULES.md の副官選択フェーズ）で、
+ * 実際 ADJUTANT フェーズ以降は GameStatus / TopHUD が常時表示している。
+ * よって `GAME_PHASES.NAPOLEON` の間だけ落とせば足りる。
+ *
+ * ⚠️ この関数はクライアントへ返す直前（maskGameStateForPlayer）専用。
+ * サーバー側の権威ある処理（setAdjutant / findAdjutant / isAdjutantCardBuried、
+ * および AI の processAdjutantPhase）は DB から読んだ未マスクの状態を使うこと。
+ * マスク済み state を権威ある処理へ流すと、AI ナポレオンの
+ * `napoleonDeclaration.adjutantCard` が消えて副官が成立しなくなる。
+ */
+function maskBiddingDeclarationForPlayer(
+  gameState: GameState,
+  viewerPlayerId: string
+): GameState {
+  if (gameState.phase !== GAME_PHASES.NAPOLEON) {
+    return gameState
+  }
+
+  // 宣言した本人（AI 含む）は自分が指定した札を当然知っている
+  const declaration = gameState.napoleonDeclaration
+  if (declaration && declaration.playerId === viewerPlayerId) {
+    return gameState
+  }
+
+  return {
+    ...gameState,
+    napoleonDeclaration: declaration
+      ? { ...declaration, adjutantCard: undefined }
+      : declaration,
+    napoleonCard: undefined,
+  }
+}
+
+/**
  * 閲覧者以外の手札・伏せ札・副官の正体をマスクしたゲーム状態を返す
  * @param gameState 未マスクのゲーム状態
  * @param viewerPlayerId 閲覧者（認証済みプレイヤー）のID
@@ -94,8 +144,8 @@ export function maskGameStateForPlayer(
   viewerPlayerId: string
 ): GameState {
   // 副官の秘匿ルールは maskAdjutantIdentityForPlayer に一本化する
-  const identityMasked = maskAdjutantIdentityForPlayer(
-    gameState,
+  const identityMasked = maskBiddingDeclarationForPlayer(
+    maskAdjutantIdentityForPlayer(gameState, viewerPlayerId),
     viewerPlayerId
   )
 

--- a/tests/components/game/GameStatus.bidding.test.tsx
+++ b/tests/components/game/GameStatus.bidding.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * 競り（ナポレオン宣言フェーズ）中の GameStatus 表示の不変条件
+ *
+ * declareNapoleon は宣言のたびに isNapoleon / trumpSuit を立てるため、
+ * 競りの最中でも「暫定ナポレオン」が state 上に存在する。それを確定した
+ * チーム・役職として描画すると、まだ上乗せできる閲覧者に対して
+ * 「自分は連合軍」「副官は誰かが隠れている」と誤った情報を与えてしまう。
+ *
+ * ここで固定するのは次の性質:
+ * - 競り中は確定チーム（Napoleon / Adjutant / Allied Forces）を描かない
+ * - 競り中は自分の役職を断定しない
+ * - 競り中の宣言は「現在の最高提示」として提示する
+ * - 競りを抜けたら従来どおり確定表示に戻る
+ */
+
+import { render, screen } from '@testing-library/react'
+import { GameStatus } from '@/components/game/GameStatus'
+import {
+  BIDDING_LABELS,
+  GAME_PHASES,
+  PLAYER_ROLES,
+  SUIT_ENUM,
+} from '@/lib/constants'
+import type { GameState, Player } from '@/types/game'
+
+const BIDDER_ID = 'ai-1'
+const VIEWER_ID = 'human'
+
+const createPlayer = (
+  id: string,
+  name: string,
+  position: number,
+  overrides: Partial<Player> = {}
+): Player => ({
+  id,
+  name,
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  position,
+  isAI: id !== VIEWER_ID,
+  ...overrides,
+})
+
+/**
+ * AI が 14 / スペードで提示済み。閲覧者（人間）はまだ上乗せできる。
+ * 副官指定カードは maskGameStateForPlayer が落とすので閲覧者側には届かない
+ */
+const createBiddingState = (overrides: Partial<GameState> = {}): GameState => ({
+  id: 'bidding-game',
+  players: [
+    createPlayer(BIDDER_ID, 'AI Player 1', 1, { isNapoleon: true }),
+    createPlayer(VIEWER_ID, 'You', 2),
+    createPlayer('ai-2', 'AI Player 2', 3),
+    createPlayer('ai-3', 'AI Player 3', 4),
+  ],
+  phase: GAME_PHASES.NAPOLEON,
+  currentPlayerIndex: 1,
+  currentTrick: { id: 'trick-1', cards: [], completed: false },
+  tricks: [],
+  hiddenCards: [],
+  trumpSuit: SUIT_ENUM.SPADES,
+  napoleonDeclaration: {
+    playerId: BIDDER_ID,
+    targetTricks: 14,
+    suit: SUIT_ENUM.SPADES,
+  },
+  passedPlayers: [],
+  declarationTurn: 1,
+  needsRedeal: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+})
+
+describe('GameStatus during the bidding phase', () => {
+  it('does not present the bid as a decided team', () => {
+    render(
+      <GameStatus
+        gameState={createBiddingState()}
+        currentPlayerId={VIEWER_ID}
+      />
+    )
+
+    expect(screen.queryByText('Teams')).not.toBeInTheDocument()
+    expect(screen.queryByText(PLAYER_ROLES.NAPOLEON)).not.toBeInTheDocument()
+    expect(screen.queryByText(PLAYER_ROLES.ADJUTANT)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Allied Forces/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Hidden/)).not.toBeInTheDocument()
+  })
+
+  it('does not assert the viewer role while they can still outbid', () => {
+    render(
+      <GameStatus
+        gameState={createBiddingState()}
+        currentPlayerId={VIEWER_ID}
+      />
+    )
+
+    expect(screen.queryByText('Role:')).not.toBeInTheDocument()
+  })
+
+  it('labels the declaration as the current highest bid', () => {
+    render(
+      <GameStatus
+        gameState={createBiddingState()}
+        currentPlayerId={VIEWER_ID}
+      />
+    )
+
+    expect(screen.getByText(BIDDING_LABELS.SECTION_TITLE)).toBeInTheDocument()
+    expect(screen.getByText(BIDDING_LABELS.UNDECIDED_NOTE)).toBeInTheDocument()
+    expect(screen.getByText(/Highest bid by:/)).toBeInTheDocument()
+    // 提示内容そのものは公開情報なので、上乗せ判断のために見えている必要がある
+    expect(screen.getByText('14')).toBeInTheDocument()
+  })
+
+  it('restores the decided team view once bidding is over', () => {
+    render(
+      <GameStatus
+        gameState={createBiddingState({ phase: GAME_PHASES.ADJUTANT })}
+        currentPlayerId={VIEWER_ID}
+      />
+    )
+
+    expect(screen.getByText('Teams')).toBeInTheDocument()
+    expect(screen.getByText(PLAYER_ROLES.NAPOLEON)).toBeInTheDocument()
+    expect(screen.getByText('Role:')).toBeInTheDocument()
+    expect(
+      screen.queryByText(BIDDING_LABELS.SECTION_TITLE)
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/lib/game/maskGameState.bidding.test.ts
+++ b/tests/lib/game/maskGameState.bidding.test.ts
@@ -1,0 +1,228 @@
+/**
+ * 競り（ナポレオン宣言フェーズ）中の「呼ぶ札」秘匿の不変条件
+ *
+ * AI は宣言と同時に副官指定カードを決め、人間は宣言後に選ぶ。この非対称のせいで
+ * 競りの最中に AI の指定カードだけが人間へ届いていた。ここで固定したいのは
+ * 実装手順ではなく次の 4 つの性質:
+ *
+ * 1. 宣言フェーズ中、宣言者以外へ渡る state には指定カードが一切残らない
+ * 2. 宣言者本人には見える
+ * 3. 宣言フェーズを抜けたら全員に見える（確定後は公開情報）
+ * 4. サーバー側の副官決定ロジックはマスク済み state では成立しない
+ *    = 権威ある処理には必ず未マスクの state を渡す必要がある
+ */
+
+import { GAME_PHASES, MASKED_CARD, SUIT_ENUM } from '@/lib/constants'
+import { maskGameStateForPlayer } from '@/lib/game/maskGameState'
+import { setAdjutant } from '@/lib/gameLogic'
+import { findAdjutant, isAdjutantCardBuried } from '@/lib/napoleonRules'
+import type { Card, GameState, Player } from '@/types/game'
+
+const NAPOLEON_ID = 'ai-1'
+const HUMAN_ID = 'human'
+const HOLDER_ID = 'ai-2'
+const OUTSIDER_ID = 'ai-3'
+
+/** AI ナポレオンが宣言時に指定した「呼ぶ札」（♠A） */
+const CALLED_CARD: Card = {
+  id: 'called-spades-a',
+  suit: SUIT_ENUM.SPADES,
+  rank: 'A',
+  value: 14,
+}
+
+const BURIED_CARD: Card = {
+  id: 'buried-hearts-a',
+  suit: SUIT_ENUM.HEARTS,
+  rank: 'A',
+  value: 14,
+}
+
+const createCard = (id: string): Card => ({
+  id,
+  suit: SUIT_ENUM.CLUBS,
+  rank: '3',
+  value: 3,
+})
+
+const createPlayer = (
+  id: string,
+  position: number,
+  hand: Card[],
+  overrides: Partial<Player> = {}
+): Player => ({
+  id,
+  name: `Player ${id}`,
+  hand,
+  isNapoleon: false,
+  isAdjutant: false,
+  position,
+  isAI: id !== HUMAN_ID,
+  ...overrides,
+})
+
+/**
+ * 競りの途中: AI ナポレオンが宣言済みだが、人間はまだ上乗せできる状態。
+ * declareNapoleon が isNapoleon / trumpSuit / napoleonCard を立てるため、
+ * この時点でも「暫定ナポレオン」は存在する
+ */
+const createBiddingState = (overrides: Partial<GameState> = {}): GameState => ({
+  id: 'bidding-game',
+  players: [
+    createPlayer(NAPOLEON_ID, 1, [createCard('n1'), createCard('n2')], {
+      isNapoleon: true,
+    }),
+    createPlayer(HUMAN_ID, 2, [createCard('h1'), createCard('h2')]),
+    // 呼ばれた札を持っている＝副官になるプレイヤー
+    createPlayer(HOLDER_ID, 3, [CALLED_CARD, createCard('a1')]),
+    createPlayer(OUTSIDER_ID, 4, [createCard('o1'), createCard('o2')]),
+  ],
+  phase: GAME_PHASES.NAPOLEON,
+  currentPlayerIndex: 1,
+  currentTrick: { id: 'trick-1', cards: [], completed: false },
+  tricks: [],
+  hiddenCards: [BURIED_CARD, createCard('hidden-2')],
+  trumpSuit: SUIT_ENUM.SPADES,
+  napoleonDeclaration: {
+    playerId: NAPOLEON_ID,
+    targetTricks: 14,
+    suit: SUIT_ENUM.SPADES,
+    adjutantCard: CALLED_CARD,
+  },
+  // declareNapoleon が互換用に複製する（gameLogic.ts）
+  napoleonCard: CALLED_CARD,
+  passedPlayers: [],
+  declarationTurn: 1,
+  needsRedeal: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+})
+
+describe('bidding phase - the called card must not leak to other bidders', () => {
+  it('hides the called card from a player who can still outbid', () => {
+    const masked = maskGameStateForPlayer(createBiddingState(), HUMAN_ID)
+
+    expect(masked.napoleonDeclaration?.adjutantCard).toBeUndefined()
+    expect(masked.napoleonCard).toBeUndefined()
+  })
+
+  it('leaves no trace of the called card anywhere in the payload', () => {
+    const masked = maskGameStateForPlayer(createBiddingState(), HUMAN_ID)
+
+    // 手札マスクの穴（呼ばれた札の持ち主の手札）も含めて漏れていないこと
+    expect(JSON.stringify(masked)).not.toContain(CALLED_CARD.id)
+  })
+
+  it('keeps the public parts of the bid visible so it can be outbid', () => {
+    const masked = maskGameStateForPlayer(createBiddingState(), HUMAN_ID)
+
+    expect(masked.napoleonDeclaration?.playerId).toBe(NAPOLEON_ID)
+    expect(masked.napoleonDeclaration?.targetTricks).toBe(14)
+    expect(masked.napoleonDeclaration?.suit).toBe(SUIT_ENUM.SPADES)
+  })
+
+  it('shows the declarer their own called card', () => {
+    const masked = maskGameStateForPlayer(createBiddingState(), NAPOLEON_ID)
+
+    expect(masked.napoleonDeclaration?.adjutantCard?.id).toBe(CALLED_CARD.id)
+    expect(masked.napoleonCard?.id).toBe(CALLED_CARD.id)
+  })
+
+  it('hides it from the player who happens to hold the called card', () => {
+    const masked = maskGameStateForPlayer(createBiddingState(), HOLDER_ID)
+
+    expect(masked.napoleonDeclaration?.adjutantCard).toBeUndefined()
+    expect(masked.napoleonCard).toBeUndefined()
+  })
+
+  it('does not mutate the server side state', () => {
+    const original = createBiddingState()
+    maskGameStateForPlayer(original, HUMAN_ID)
+
+    expect(original.napoleonDeclaration?.adjutantCard?.id).toBe(CALLED_CARD.id)
+    expect(original.napoleonCard?.id).toBe(CALLED_CARD.id)
+  })
+
+  it('does not crash when nobody has declared yet', () => {
+    const masked = maskGameStateForPlayer(
+      createBiddingState({
+        napoleonDeclaration: undefined,
+        napoleonCard: undefined,
+      }),
+      HUMAN_ID
+    )
+
+    expect(masked.napoleonDeclaration).toBeUndefined()
+    expect(masked.napoleonCard).toBeUndefined()
+  })
+})
+
+describe('after bidding closes - the called card is public', () => {
+  const phasesAfterBidding = [
+    GAME_PHASES.ADJUTANT,
+    GAME_PHASES.EXCHANGE,
+    GAME_PHASES.PLAYING,
+    GAME_PHASES.FINISHED,
+  ]
+
+  it.each(phasesAfterBidding)('exposes it to everyone in %s', (phase) => {
+    const state = createBiddingState({ phase })
+
+    for (const viewerId of [NAPOLEON_ID, HUMAN_ID, HOLDER_ID, OUTSIDER_ID]) {
+      const masked = maskGameStateForPlayer(state, viewerId)
+
+      expect(masked.napoleonDeclaration?.adjutantCard?.id).toBe(CALLED_CARD.id)
+      expect(masked.napoleonCard?.id).toBe(CALLED_CARD.id)
+    }
+  })
+})
+
+/**
+ * マスクは「クライアントへ返す直前」だけのもので、副官を決める権威ある処理は
+ * 未マスクの state を読む。マスク済み state を流し込むと副官が成立しない
+ * ことをここで固定し、両者が取り違えられたら落ちるようにしておく
+ */
+describe('server side adjutant resolution runs on the unmasked state', () => {
+  it('findAdjutant locates the holder in the unmasked state', () => {
+    const state = createBiddingState()
+
+    expect(findAdjutant(state, CALLED_CARD)?.id).toBe(HOLDER_ID)
+    expect(isAdjutantCardBuried(state, CALLED_CARD)).toBe(false)
+    expect(isAdjutantCardBuried(state, BURIED_CARD)).toBe(true)
+  })
+
+  it('cannot resolve the adjutant from a client masked state', () => {
+    const masked = maskGameStateForPlayer(createBiddingState(), HUMAN_ID)
+
+    // 他プレイヤーの手札も埋め札もダミーに置き換わっているため、
+    // 「誰が持っているか」「埋まっているか」を判定する材料が残っていない
+    expect(findAdjutant(masked, CALLED_CARD)).toBeNull()
+    expect(isAdjutantCardBuried(masked, BURIED_CARD)).toBe(false)
+    for (const card of masked.hiddenCards) {
+      expect(card.id.startsWith(MASKED_CARD.ID_PREFIX)).toBe(true)
+    }
+  })
+
+  it('setAdjutant flags the real holder when given the unmasked state', () => {
+    const state = createBiddingState({ phase: GAME_PHASES.ADJUTANT })
+    const result = setAdjutant(state, CALLED_CARD)
+
+    expect(result.players.find((p) => p.isAdjutant)?.id).toBe(HOLDER_ID)
+    expect(result.soloNapoleon).toBe(false)
+    expect(result.napoleonCard?.id).toBe(CALLED_CARD.id)
+  })
+
+  it('setAdjutant on a masked state would wrongly produce a solo Napoleon', () => {
+    // 取り違え検知用。マスク済みビューでは誰も副官になれず、埋め札判定も
+    // 外れるため「副官不在なのに soloNapoleon でもない」壊れた state になる
+    const masked = maskGameStateForPlayer(
+      createBiddingState({ phase: GAME_PHASES.ADJUTANT }),
+      HUMAN_ID
+    )
+    const result = setAdjutant(masked, CALLED_CARD)
+
+    expect(result.players.some((p) => p.isAdjutant)).toBe(false)
+    expect(result.soloNapoleon).toBe(false)
+  })
+})


### PR DESCRIPTION
## 症状

ナポレオン宣言フェーズで、**AI が指定した副官カードが人間プレイヤーの画面に表示されていました**。

スクリーンショットの状況: 現在の最高提示は AI Player 1 の「14枚・スペード」。人間はまだ 15 で上乗せできる段階なのに、右パネルに `ADJUTANT CARD A♠` が出ている。**どの札が呼ばれているかを知った上で上乗せ判断ができてしまいます。**

## 根本原因: AI と人間で宣言のルールが非対称

- **AI** は宣言時に副官カードを確定させる（`src/lib/ai/napoleon.ts:214-217`）
- **人間** の宣言フォーム（`src/components/game/NapoleonSelector.tsx:124-131`）には副官カードの選択が無く、`playerId` / `targetTricks` / `suit` のみ。副官カードは宣言後の `AdjutantSelector` で選ぶ
- `maskGameStateForPlayer` は `napoleonDeclaration` を**一切マスクしていなかった**

## 漏洩経路は 2 つあった

`declareNapoleon` は `adjutantCard` を **`napoleonCard` へも複製**しており（`src/lib/gameLogic.ts:138`「互換性のため古い形式も保持」）、右パネルが実際に表示していたのは**後者**です（`src/components/game/GameStatus.tsx:121`）。

つまり `napoleonDeclaration.adjutantCard` だけ塞いでも漏れ続けます。両方を落としています。

なお `GameStatus.tsx:120` には「副官「指定カード」は宣言時に全員へ告げられる公開情報」というコメントがありました。**ナポレオン確定後は**そのとおりですが、競りの最中は別です。

## 修正

`phase === NAPOLEON` かつ**閲覧者が宣言者でない**場合に限り、`napoleonDeclaration.adjutantCard` と `napoleonCard` の両方を落とします。呼ぶ札は確定後には公開情報（`docs/game-logic/NAPOLEON_RULES.md` の副官選択フェーズ）なので、隠すのは競りの最中だけです。

**UI での出し分けではなくサーバ側マスクにしています。**UI だけだと通信内容に残るためです。テストではペイロード全体を `JSON.stringify` して札 ID が残らないことまで検証しています。

### #510 の再発防止

マスクは**クライアントへ返す直前の `maskGameStateForPlayer` にのみ**挟みました。サーバ側 AI ビューを作る `maskAdjutantIdentityForPlayer` には触れていません。#510 で「マスク済み state を権威ある処理へ流して `phase` が壊れる」事故を起こしているため、同じ経路を増やさない方針です。

`setAdjutant` / `findAdjutant` / `isAdjutantCardBuried` が**未マスク state で動く**こと、そして**マスク済み state では副官を解決できない**ことを、取り違えたら落ちる形でテストに固定しました。

呼び出し経路も確認済みです。`setAdjutantAction` は DB から読んだ state をそのまま `setAdjutant` に渡し、AI 側も `processAITurn` → `processAdjutantPhase` が未マスク state から読みます。`maskGameStateForPlayer` の呼び出し 12 箇所はすべて server action の `return` か Realtime の `onUpdate` 直前でした。

## あわせて直した表示の先走り

`declareNapoleon` は**宣言のたびに `isNapoleon: true` を立てる**（`gameLogic.ts:119-125`）ため、まだ競っている最中でも Teams ブロックが確定チームのように描画されていました。

```
Teams: Napoleon = AI Player 1 / Adjutant ??? (Hidden)
Allied Forces: You, AI Player 2, AI Player 3
Your Stats — Role: Allied Forces
```

人間が上乗せすればナポレオンになるので誤りです。競り中は Teams と Role を出さず、見出しを `Current Highest Bid` にして未確定であることを明示します。

Teams ブロックは**丸ごと非表示**にしました。「暫定ナポレオン」を括弧書きで出す案もありましたが、最高提示者は同じパネルの Current Highest Bid が既に示しているため重複と判断しています。ここは好みが分かれるかもしれません。

## テスト（新規 19 件）

- `maskGameState.bidding.test.ts`（15）— 宣言者以外には両フィールドとも undefined／ペイロード全体に札 ID が残らない／宣言者本人には見える／ADJUTANT・EXCHANGE・PLAYING・FINISHED では全員に見える／原本を破壊しない／サーバ側の副官解決が未マスクで動く
- `GameStatus.bidding.test.tsx`（4）— 競り中に確定チーム・Role を描かない／最高提示として提示する／フェーズを抜けたら従来表示に戻る

**修正を戻すと失敗することを確認済み**（マスク revert で 3 件、GameStatus revert で 3 件）。

`65 suites / 848 tests` → **`67 suites / 867 tests`**、既存の失敗 0 件。`pnpm ci-check` exit 0。

## 未対応（重要）

**Supabase Realtime の生ペイロードには依然として呼ぶ札が乗っています。** `secureGameService.ts:266-269` のコメントどおり `payload.new.state` は未マスクの行で、アプリ状態にする前にマスクを通す方式です。DevTools で WebSocket フレームを直接覗けば競り中でも見えます。**今回持ち込んだものではなく、手札の漏洩と同じ既存の穴**で、根治には `games` テーブル側の Realtime/RLS 設定が必要です。今回は手を付けていません。

**実プレイでの目視確認はしていません。**検証はユニットテストと `next build` までです。

## 検討: AI 側を人間に合わせるべきか（今回は変更せず）

マスクは症状の封じ込めであって、非対称そのものは残ります。`adjutantCard` は宣言オブジェクトに載った瞬間 `napoleonCard` のように波及するので、派生フィールドが増えれば同じ穴がまた開きます。

`processAdjutantPhase`（`ai/gameTricks.ts:118-122`）は `adjutantCard` が無ければ ADJUTANT を素通りする作りなので、ここを「ADJUTANT フェーズで `selectAdjutantCard` を呼ぶ」に付け替えれば、人間と同じ「宣言 → 確定 → 指定」の 1 本道になります。

`selectAdjutantCard` は自分の手札と宣言スートしか見ていないため理屈上は強さに影響しないはずですが、**MCTS 経路（`napoleonMCTS.ts`）が宣言の評価に `adjutantCard` 込みの declaration を使っているかは未確認**です。勝率計測付きの別タスクとするのが妥当と判断し、今回は変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 73160fc fix(game): 競り中に副官の指定カードが他プレイヤーへ漏れるのを止める

## 📁 Files Changed

**Total files changed: 5**

- 🔧 **Source Code**: 3 files
- 🧪 **Tests**: 2 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/components/game/GameStatus.bidding.test.tsx`
- `tests/lib/game/maskGameState.bidding.test.ts`

#### 📚 Documentation


#### 🔧 Source Code

- `src/components/game/GameStatus.tsx`
- `src/lib/constants.ts`
- `src/lib/game/maskGameState.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added
- 💄 **UI/UX** - User interface improvements

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout fix/hide-adjutant-card-during-bidding
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*