### PR TITLE
feat(ui): ナポレオンの宣言絵札数を盤面から読めるようにする

### DIFF
--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { calculateGameResultAction } from '@/app/actions/gameResultActions'
 import { AIDifficultyBadge } from '@/components/game/AIDifficultyBadge'
 import { Card } from '@/components/game/Card'
-import { CompactGameProgress, GameStatus } from '@/components/game/GameStatus'
+import { GameStatus } from '@/components/game/GameStatus'
 import { PlayerHand } from '@/components/game/PlayerHand'
 import { TopHUD } from '@/components/game/TopHUD'
 import { TurnCue } from '@/components/game/TurnCue'
@@ -335,11 +335,6 @@ function GamePageContent() {
 
             <div className="grid grid-cols-1 lg:grid-cols-4 gap-2 md:gap-6">
               <div className="lg:col-span-3 space-y-2 md:space-y-6">
-                {/* コンパクトなProgress表示 - モバイルのみ */}
-                <div className="lg:hidden">
-                  <CompactGameProgress gameState={gameState} />
-                </div>
-
                 {/* ゲームボード - 最後のトリックのカードを表示 */}
                 <GameBoard
                   gameState={gameState}
@@ -655,10 +650,6 @@ function GamePageContent() {
                   onCardExchange={handleCardExchange}
                 />
               )}
-
-            <div className="lg:hidden">
-              <CompactGameProgress gameState={gameState} />
-            </div>
 
             {currentPlayer && (
               <div className="space-y-2 md:space-y-4">

--- a/src/components/game/AdjutantSelector.tsx
+++ b/src/components/game/AdjutantSelector.tsx
@@ -5,6 +5,7 @@ import {
   ACTION_TYPES,
   CARD_RANKS,
   createDeck,
+  DECLARATION_LABELS,
   SUIT_ENUM,
   SUIT_NAMES,
   SUIT_SYMBOLS,
@@ -164,7 +165,10 @@ export function AdjutantSelector({
             <div className="text-2xl font-bold text-yellow-700">
               {gameState.napoleonDeclaration.targetTricks}
             </div>
-            <div className="text-sm text-yellow-600">tricks</div>
+            {/* targetTricks は「絵札数」。トリック数と取り違えられないようにする */}
+            <div className="text-sm text-yellow-600">
+              {DECLARATION_LABELS.FACE_CARDS}
+            </div>
           </div>
           <div className="text-center">
             <div className={`text-3xl font-bold ${getSuitColor(trumpSuit)}`}>

--- a/src/components/game/DeclarationDisplay.tsx
+++ b/src/components/game/DeclarationDisplay.tsx
@@ -1,6 +1,10 @@
 'use client'
 
-import { SUIT_DISPLAY_COLORS, SUIT_NAMES } from '@/lib/constants'
+import {
+  DECLARATION_LABELS,
+  SUIT_DISPLAY_COLORS,
+  SUIT_NAMES,
+} from '@/lib/constants'
 import type { NapoleonDeclaration, Suit } from '@/types/game'
 import {
   ADJUTANT_BADGE_SUIT_LABELS,
@@ -38,7 +42,9 @@ export function DeclarationDisplay({
             <div className="text-2xl font-bold text-yellow-700">
               {declaration.targetTricks}
             </div>
-            <div className="text-sm text-yellow-600">face cards</div>
+            <div className="text-sm text-yellow-600">
+              {DECLARATION_LABELS.FACE_CARDS}
+            </div>
           </div>
           <div className="text-center">
             <div

--- a/src/components/game/GameStatus.tsx
+++ b/src/components/game/GameStatus.tsx
@@ -4,18 +4,18 @@ import {
   BIDDING_LABELS,
   DECLARATION_LABELS,
   GAME_PHASES,
-  NAPOLEON_RULES,
   PLAYER_ROLES,
   SOLO_NAPOLEON_LABELS,
   SUIT_SYMBOLS,
 } from '@/lib/constants'
-import {
-  getGameProgress,
-  getPlayerFaceCardCount,
-  getPlayerStats,
-} from '@/lib/scoring'
+import { getPlayerStats } from '@/lib/scoring'
 import type { GameState } from '@/types/game'
-import { isSoloNapoleon, showsAdjutantBadge } from '@/utils/gameUtils'
+import {
+  checkAdjutantRevealed,
+  isAdjutantIdentityPublic,
+  isSoloNapoleon,
+  showsAdjutantBadge,
+} from '@/utils/gameUtils'
 import {
   ADJUTANT_BADGE_SUIT_LABELS,
   ADJUTANT_BADGE_TONES,
@@ -28,7 +28,6 @@ interface GameStatusProps {
 }
 
 export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
-  const progress = getGameProgress(gameState)
   const napoleonPlayer = gameState.players.find((p) => p.isNapoleon)
   const adjutantPlayer = gameState.players.find((p) => p.isAdjutant)
   // マスク済みなので、閲覧者に公開してよい場合のみ true になる
@@ -53,28 +52,19 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
     return roleMap[role as keyof typeof roleMap] || role
   }
 
-  // 副官が判明しているかどうかをチェック
-  // 1. 副官プレイヤーが副官指定カードを出した場合（従来）
-  // 2. ナポレオンが隠しカードから副官指定カードを出した場合（新機能）
-  const isAdjutantRevealed =
-    gameState.phase === GAME_PHASES.PLAYING &&
-    // ケース1: 副官プレイヤーが副官指定カードを出した
-    ((adjutantPlayer &&
-      gameState.tricks.some((trick) =>
-        trick.cards.some(
-          (playedCard) =>
-            gameState.napoleonCard &&
-            playedCard.card.id === gameState.napoleonCard.id
-        )
-      )) ||
-      // ケース2: ナポレオンが隠しカードから副官指定カードを出した
-      gameState.tricks.some((trick) =>
-        trick.cards.some((playedCard) => playedCard.revealsAdjutant)
-      ) ||
-      // ケース3: 現在のトリックでナポレオンが隠しカードから副官カードを出した
-      gameState.currentTrick.cards.some(
-        (playedCard) => playedCard.revealsAdjutant
-      ))
+  // 副官の正体を出してよいかは共通ヘルパーに委ねる。
+  // 旧実装はここで `phase === PLAYING` を先頭条件に置いた独自式を持っていたが、
+  // GameStatus は PLAYING では描画されない（PLAYING は page.tsx の専用
+  // レイアウトが TopHUD だけを出す）ため、常に false になっていた。
+  // その結果、実際に描画される終了画面でも副官が「??? (Hidden)」のままだった。
+  // 判定を二重に持たず isAdjutantIdentityPublic に一本化する
+  // （競り前フェーズはトリックが 1 つも無いので、従来どおり非公開のまま）
+  const isAdjutantRevealed = isAdjutantIdentityPublic(gameState)
+
+  // 副官指定カードが実際に場に出たか。早期終了（isGameDecided）では
+  // 1 度も出ないまま終わるため、「このカードで見つかった」という表示だけは
+  // 正体の公開可否ではなくカードが出たかどうかで判定する
+  const adjutantCardPlayed = checkAdjutantRevealed(gameState)
 
   // 一人ナポレオンで公開済みなら、ナポレオン本人を副官としても表示する。
   // 判定は共通ヘルパーに委ねる（player.isAdjutant は立てていない）
@@ -82,7 +72,7 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
     ? showsAdjutantBadge({
         player: napoleonPlayer,
         soloNapoleon,
-        isAdjutantRevealed: Boolean(isAdjutantRevealed),
+        isAdjutantRevealed,
       })
     : false
 
@@ -232,105 +222,6 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
         </div>
       )}
 
-      {/* ゲーム進行状況 */}
-      {gameState.phase === GAME_PHASES.PLAYING && (
-        <div className="border-b pb-3">
-          <h4 className="font-semibold text-gray-800 mb-2">Progress</h4>
-          <div className="space-y-2 text-sm">
-            <div className="flex justify-between">
-              <span>Tricks Played:</span>
-              <span>{progress.tricksPlayed}/12</span>
-            </div>
-            <div className="flex justify-between">
-              <span>{PLAYER_ROLES.NAPOLEON} Team Face Cards:</span>
-              <span className="font-medium text-yellow-600">
-                {progress.napoleonTeamFaceCards}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span>Allied Forces Face Cards:</span>
-              <span className="font-medium text-blue-600">
-                {progress.citizenTeamFaceCards}
-              </span>
-            </div>
-            <div className="flex justify-between text-xs text-gray-600">
-              <span>{PLAYER_ROLES.NAPOLEON} needs:</span>
-              <span>{progress.napoleonNeedsToWin} more face cards</span>
-            </div>
-
-            {/* プログレスバー */}
-            <div className="mt-3">
-              <div className="flex justify-between text-xs mb-1">
-                <span>{PLAYER_ROLES.NAPOLEON} Face Card Progress</span>
-                <span>
-                  {progress.napoleonTeamFaceCards}/
-                  {gameState.napoleonDeclaration?.targetTricks ??
-                    NAPOLEON_RULES.TARGET_FACE_CARDS}
-                </span>
-              </div>
-              <div className="w-full bg-gray-200 rounded-full h-2">
-                <div
-                  className="bg-yellow-500 h-2 rounded-full transition-all duration-300"
-                  style={{
-                    width: `${(progress.napoleonTeamFaceCards / (gameState.napoleonDeclaration?.targetTricks ?? NAPOLEON_RULES.TARGET_FACE_CARDS)) * 100}%`,
-                  }}
-                ></div>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* プレイヤー別絵札獲得数 */}
-      {gameState.phase === GAME_PHASES.PLAYING && (
-        <div className="border-b pb-3">
-          <h4 className="font-semibold text-gray-800 mb-2">
-            Face Cards Won by Player
-          </h4>
-          <div className="space-y-1 text-sm">
-            {gameState.players.map((player) => {
-              const faceCardsWon = getPlayerFaceCardCount(gameState, player.id)
-              // 一人ナポレオンの公開後は、ナポレオンに N と A の両方が付く
-              const showAdjutantMark = showsAdjutantBadge({
-                player,
-                soloNapoleon,
-                isAdjutantRevealed: Boolean(isAdjutantRevealed),
-              })
-              const roleColor = player.isNapoleon
-                ? 'text-yellow-600'
-                : showAdjutantMark
-                  ? 'text-green-600'
-                  : 'text-blue-600'
-
-              return (
-                <div
-                  key={player.id}
-                  className="flex justify-between items-center"
-                >
-                  <div className="flex items-center gap-2">
-                    <span>{player.name}</span>
-                    {player.isNapoleon && (
-                      <span className="px-1 py-0 bg-yellow-200 text-yellow-800 rounded text-xs">
-                        N
-                      </span>
-                    )}
-                    {showAdjutantMark && (
-                      <span className="px-1 py-0 bg-green-200 text-green-800 rounded text-xs">
-                        A
-                      </span>
-                    )}
-                  </div>
-                  <span className={`font-medium ${roleColor}`}>
-                    {faceCardsWon} face cards
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {/* 現在のプレイヤー情報 */}
       {currentPlayerStats && (
         <div className="border-b pb-3">
           <h4 className="font-semibold text-gray-800 mb-2">Your Stats</h4>
@@ -381,8 +272,9 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
         </div>
       )}
 
-      {/* 副官指定カードは隠す - 判明後のみヒント表示 */}
-      {gameState.napoleonCard && isAdjutantRevealed && (
+      {/* 「このカードで副官が見つかった」は、指定カードが実際に場に出た
+          ときだけ意味を持つ。早期終了で 1 度も出ずに終わった場合に出すと嘘になる */}
+      {gameState.napoleonCard && adjutantCardPlayed && (
         <div className="bg-green-50 border border-green-200 p-3 rounded-lg">
           <div className="text-sm text-green-700">
             <span className="font-semibold">
@@ -392,63 +284,6 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
               {gameState.napoleonCard.rank} of {gameState.napoleonCard.suit}
             </span>
           </div>
-        </div>
-      )}
-    </div>
-  )
-}
-
-// モバイル用のコンパクトなProgress表示
-export function CompactGameProgress({ gameState }: { gameState: GameState }) {
-  const progress = getGameProgress(gameState)
-  const napoleonPlayer = gameState.players.find((p) => p.isNapoleon)
-
-  // PLAYINGフェーズでのみ表示
-  if (gameState.phase !== GAME_PHASES.PLAYING) {
-    return null
-  }
-
-  return (
-    <div className="bg-white rounded-lg shadow-md p-2 text-xs">
-      <div className="flex items-center justify-between gap-2">
-        {/* Tricks */}
-        <div className="flex flex-col items-center">
-          <span className="text-gray-600">Tricks</span>
-          <span className="font-bold text-sm">{progress.tricksPlayed}/12</span>
-        </div>
-
-        {/* Napoleon Team */}
-        <div className="flex flex-col items-center">
-          <span className="text-gray-600">Napoleon</span>
-          <span className="font-bold text-yellow-600 text-sm">
-            {progress.napoleonTeamFaceCards}
-          </span>
-        </div>
-
-        {/* Alliance Team */}
-        <div className="flex flex-col items-center">
-          <span className="text-gray-600">Alliance</span>
-          <span className="font-bold text-blue-600 text-sm">
-            {progress.citizenTeamFaceCards}
-          </span>
-        </div>
-
-        {/* Napoleon needs */}
-        <div className="flex flex-col items-center text-center">
-          <span className="text-gray-600">Napoleon needs</span>
-          <span className="font-bold text-sm">
-            {progress.napoleonNeedsToWin} more
-          </span>
-        </div>
-      </div>
-
-      {/* Adjutant Card info - コンパクト表示 */}
-      {gameState.napoleonCard && napoleonPlayer && (
-        <div className="mt-1 pt-1 border-t text-center text-gray-600">
-          <span className="text-[0.65rem]">
-            Adjutant Card: {gameState.napoleonCard.rank}{' '}
-            {SUIT_SYMBOLS[gameState.napoleonCard.suit]}
-          </span>
         </div>
       )}
     </div>

--- a/src/components/game/GameStatus.tsx
+++ b/src/components/game/GameStatus.tsx
@@ -2,6 +2,7 @@
 
 import {
   BIDDING_LABELS,
+  DECLARATION_LABELS,
   GAME_PHASES,
   NAPOLEON_RULES,
   PLAYER_ROLES,
@@ -106,8 +107,10 @@ export function GameStatus({ gameState, currentPlayerId }: GameStatusProps) {
                 <div className="text-base md:text-xl font-bold text-yellow-700">
                   {gameState.napoleonDeclaration.targetTricks}
                 </div>
+                {/* targetTricks は「絵札数」。トリック数ではないので
+                    ラベルを face cards にして誤解を防ぐ */}
                 <div className="text-[0.6rem] md:text-xs text-yellow-600">
-                  tricks
+                  {DECLARATION_LABELS.FACE_CARDS}
                 </div>
               </div>
               <div className="text-center">

--- a/src/components/game/TopHUD.tsx
+++ b/src/components/game/TopHUD.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import { memo, useMemo } from 'react'
-import { SOLO_NAPOLEON_LABELS, SUIT_SYMBOLS } from '@/lib/constants'
+import {
+  DECLARATION_LABELS,
+  GAME_CONFIG,
+  NAPOLEON_RULES,
+  PLAYER_ROLES,
+  SOLO_NAPOLEON_LABELS,
+  SUIT_SYMBOLS,
+} from '@/lib/constants'
 import { getGameProgress } from '@/lib/scoring'
 import type { GameState } from '@/types/game'
 import { isSoloNapoleon } from '@/utils/gameUtils'
@@ -18,11 +25,15 @@ export const TopHUD = memo(function TopHUD({
 }: TopHUDProps) {
   const progress = useMemo(() => getGameProgress(gameState), [gameState])
 
-  const targetFaceCards = gameState.napoleonDeclaration?.targetTricks ?? 13
-  const totalFaceCards = 20
+  const targetFaceCards =
+    gameState.napoleonDeclaration?.targetTricks ??
+    NAPOLEON_RULES.TARGET_FACE_CARDS
+  const totalFaceCards = NAPOLEON_RULES.TOTAL_FACE_CARDS
 
   const napPercent = (progress.napoleonTeamFaceCards / totalFaceCards) * 100
   const alliPercent = (progress.citizenTeamFaceCards / totalFaceCards) * 100
+  // バー上での宣言ラインの位置。「どこまで伸びれば達成なのか」を可視化する
+  const targetPercent = (targetFaceCards / totalFaceCards) * 100
 
   const trumpSuit = gameState.trumpSuit ?? gameState.napoleonDeclaration?.suit
 
@@ -44,34 +55,93 @@ export const TopHUD = memo(function TopHUD({
           Trick
         </span>
         <span className="text-base font-extrabold text-white">
-          {progress.tricksPlayed} / 12
+          {progress.tricksPlayed} / {GAME_CONFIG.CARDS_PER_PLAYER}
         </span>
       </div>
 
+      {/* 宣言した絵札数は盤面で最も参照される公開情報。
+          進捗バーの補足に埋もれないよう、トリック数と対等な独立チップにする */}
+      {gameState.napoleonDeclaration && (
+        <div className="flex items-center gap-2 bg-yellow-500/20 border border-yellow-400/40 rounded-[10px] px-3 py-1.5">
+          <span className="text-[10px] tracking-widest uppercase text-yellow-200 font-bold">
+            {DECLARATION_LABELS.DECLARED}
+          </span>
+          <span className="text-xl leading-none font-extrabold text-yellow-300">
+            {targetFaceCards}
+          </span>
+          <span className="text-[10px] font-semibold text-yellow-200/90">
+            {DECLARATION_LABELS.FACE_CARDS}
+          </span>
+        </div>
+      )}
+
       {/* Face card progress bar */}
       <div className="flex-1 min-w-[180px] flex flex-col gap-0.5 order-last lg:order-none w-full lg:w-auto">
-        <span className="text-[10px] tracking-widest uppercase text-green-300 font-bold">
-          Face cards toward declaration ({targetFaceCards})
-        </span>
-        <div className="h-2 rounded-full bg-white/10 overflow-hidden flex">
+        <div className="flex items-baseline justify-between gap-2">
+          <span className="text-[10px] tracking-widest uppercase text-green-300 font-bold">
+            {DECLARATION_LABELS.PROGRESS}
+          </span>
+          <span className="text-sm font-extrabold text-white whitespace-nowrap">
+            <span className="text-yellow-300">
+              {progress.napoleonTeamFaceCards}
+            </span>
+            {' / '}
+            {targetFaceCards}
+          </span>
+        </div>
+        <div className="relative h-2 rounded-full bg-white/10 overflow-hidden">
+          <div className="absolute inset-0 flex">
+            <div
+              className="h-full bg-yellow-500 transition-all duration-300"
+              style={{ width: `${napPercent}%` }}
+            />
+            <div
+              className="h-full bg-blue-400 transition-all duration-300"
+              style={{ width: `${alliPercent}%` }}
+            />
+          </div>
+          {/* 宣言ラインの目印 */}
           <div
-            className="h-full bg-yellow-500 transition-all duration-300"
-            style={{ width: `${napPercent}%` }}
-          />
-          <div
-            className="h-full bg-blue-400 transition-all duration-300"
-            style={{ width: `${alliPercent}%` }}
+            className="absolute top-0 bottom-0 w-0.5 bg-white/80"
+            style={{ left: `${targetPercent}%` }}
           />
         </div>
-        <div className="flex justify-between text-[11px] text-white/80 mt-0.5">
-          <span className="text-yellow-400">
-            <b>{progress.napoleonTeamFaceCards}</b> Napoleon
+        {/* 獲得枚数と「あと何枚か」を両陣営分そろえる。
+            連合軍は達成枚数ではなく阻止までの残り枚数を知りたいため */}
+        <div className="flex flex-wrap justify-between gap-x-3 gap-y-0.5 mt-1 text-xs">
+          <span className="text-yellow-300">
+            {progress.napoleonTeamFaceCards} {PLAYER_ROLES.NAPOLEON}
+            {DECLARATION_LABELS.SEPARATOR}
+            {progress.napoleonNeedsToWin > 0 ? (
+              <>
+                {DECLARATION_LABELS.NEEDS}{' '}
+                <b className="text-sm font-extrabold">
+                  {progress.napoleonNeedsToWin}
+                </b>{' '}
+                {DECLARATION_LABELS.MORE}
+              </>
+            ) : (
+              <b className="font-extrabold">
+                {DECLARATION_LABELS.NAPOLEON_MET}
+              </b>
+            )}
           </span>
-          <span className="text-blue-400">
-            <b>{progress.citizenTeamFaceCards}</b> Alliance
-          </span>
-          <span>
-            Napoleon needs <b>{progress.napoleonNeedsToWin}</b> more
+          <span className="text-blue-300">
+            {progress.citizenTeamFaceCards} {PLAYER_ROLES.ALLIED_FORCES}
+            {DECLARATION_LABELS.SEPARATOR}
+            {progress.allianceNeedsToWin > 0 ? (
+              <>
+                {DECLARATION_LABELS.NEED}{' '}
+                <b className="text-sm font-extrabold">
+                  {progress.allianceNeedsToWin}
+                </b>{' '}
+                {DECLARATION_LABELS.MORE}
+              </>
+            ) : (
+              <b className="font-extrabold">
+                {DECLARATION_LABELS.ALLIANCE_MET}
+              </b>
+            )}
           </span>
         </div>
       </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -197,6 +197,24 @@ export const GAME_CONFIG = {
   TARGET_FACE_CARDS: 13, // ナポレオンが取る必要がある絵札数
 } as const
 
+// ナポレオン宣言（絵札数）の表示ラベル。
+// 型のフィールド名が `targetTricks` であるためトリック数と誤解されやすいが、
+// 実体は「取る予定の絵札数（10〜A の 20 枚中）」なので、
+// 画面には必ず face cards であることが分かる語を出す
+export const DECLARATION_LABELS = {
+  DECLARED: 'Declared',
+  FACE_CARDS: 'face cards',
+  PROGRESS: 'Face cards toward declaration',
+  // 「あと何枚」を両陣営の視点で出す。連合軍は達成枚数ではなく
+  // 「あと何枚奪えば阻止できるか」が知りたいため、残り枚数を必ず併記する
+  NEEDS: 'needs', // Napoleon（単数）
+  NEED: 'need', // Allied Forces（複数）
+  MORE: 'more',
+  SEPARATOR: ' · ',
+  NAPOLEON_MET: 'declaration met',
+  ALLIANCE_MET: 'declaration blocked',
+} as const
+
 export const NAPOLEON_RULES = {
   TARGET_FACE_CARDS: 13, // 絵札（10〜A）の最低獲得枚数
   TOTAL_FACE_CARDS: 20, // 場に存在する絵札の総数（10, J, Q, K, A × 4スート）

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -175,6 +175,7 @@ export function getGameProgress(gameState: GameState): {
   napoleonTeamFaceCards: number
   citizenTeamFaceCards: number
   napoleonNeedsToWin: number
+  allianceNeedsToWin: number
 } {
   const { napoleonTeam, citizenTeam } = getTeamFaceCardCounts(gameState)
   const tricksPlayed = gameState.tricks.length
@@ -186,12 +187,20 @@ export function getGameProgress(gameState: GameState): {
     NAPOLEON_RULES.TARGET_FACE_CARDS
   const napoleonNeedsToWin = Math.max(0, targetFaceCards - napoleonTeam)
 
+  // 連合軍の勝利は「宣言の阻止」。isGameDecided と同じ条件
+  // （citizenTeamFaceCards > TOTAL - target）を満たす最小枚数から逆算する。
+  // 連合軍視点では「あと何枚奪えば阻止が確定するか」がそのまま目標になる
+  const allianceTargetFaceCards =
+    NAPOLEON_RULES.TOTAL_FACE_CARDS - targetFaceCards + 1
+  const allianceNeedsToWin = Math.max(0, allianceTargetFaceCards - citizenTeam)
+
   return {
     tricksPlayed,
     tricksRemaining,
     napoleonTeamFaceCards: napoleonTeam,
     citizenTeamFaceCards: citizenTeam,
     napoleonNeedsToWin,
+    allianceNeedsToWin,
   }
 }
 

--- a/tests/components/game/GameStatus.adjutantRevealGate.test.tsx
+++ b/tests/components/game/GameStatus.adjutantRevealGate.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * GameStatus が副官の正体を公開するタイミングの不変条件テスト
+ *
+ * GameStatus はかつて `phase === GAME_PHASES.PLAYING &&` で始まる独自の
+ * 公開判定を持っていた。しかし GameStatus は PLAYING では描画されない
+ * （page.tsx の PLAYING 専用レイアウトは TopHUD だけを出す）ため、
+ * この判定は常に false になり、終了画面でも副官が「??? (Hidden)」のままだった。
+ *
+ * 判定は gameUtils.isAdjutantIdentityPublic に一本化してある。
+ * ここでは「実際に描画されるフェーズ」だけを対象に、次の 2 点を固定する:
+ * - 終了画面（FINISHED）では副官の正体が Teams に出る
+ * - 競り前・競り後の準備フェーズでは絶対に出ない（#511 の情報漏れ対策を維持）
+ */
+
+import { render, screen, within } from '@testing-library/react'
+import { GameStatus } from '@/components/game/GameStatus'
+import { GAME_PHASES, PLAYER_ROLES } from '@/lib/constants'
+import type { Card, GameState, Player } from '@/types/game'
+import { isAdjutantIdentityPublic } from '@/utils/gameUtils'
+
+const adjutantCard: Card = {
+  id: 'adjutant-card',
+  suit: 'hearts',
+  rank: 'K',
+  value: 13,
+}
+
+const NAPOLEON_NAME = 'Napoleon Player'
+const ADJUTANT_NAME = 'Second Player'
+const HIDDEN_ADJUTANT_TEXT = '??? (Hidden)'
+
+/**
+ * GameStatus が実際に描画される、副官がまだ公開されないフェーズ。
+ * NAPOLEON（競り中）は Teams ブロック自体が出ないため別で検証する
+ */
+const PRE_REVEAL_PHASES = [
+  GAME_PHASES.DEALING,
+  GAME_PHASES.ADJUTANT,
+  GAME_PHASES.EXCHANGE,
+] as const
+
+const createPlayer = (
+  id: string,
+  name: string,
+  overrides: Partial<Player> = {}
+): Player => ({
+  id,
+  name,
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  position: 1,
+  isAI: false,
+  ...overrides,
+})
+
+/**
+ * @param adjutantIsMasked maskGameStateForPlayer は未公開の閲覧者へ
+ *   isAdjutant: false を渡す。公開前フェーズではこれを模す
+ */
+const createGameState = (
+  phase: GameState['phase'],
+  adjutantIsMasked: boolean
+): GameState => ({
+  id: 'reveal-gate-test',
+  players: [
+    createPlayer('nap', NAPOLEON_NAME, { isNapoleon: true }),
+    createPlayer('p2', ADJUTANT_NAME, { isAdjutant: !adjutantIsMasked }),
+    createPlayer('p3', 'Third Player'),
+    createPlayer('p4', 'Fourth Player'),
+  ],
+  phase,
+  currentPlayerIndex: 0,
+  currentTrick: { id: 'trick-1', cards: [], completed: false },
+  // 副官指定カードは 1 度も場に出ていない（早期終了を模す）
+  tricks: [],
+  hiddenCards: [],
+  napoleonCard: adjutantCard,
+  trumpSuit: 'spades',
+  napoleonDeclaration: {
+    playerId: 'nap',
+    targetTricks: 14,
+    suit: 'spades',
+    adjutantCard,
+  },
+  passedPlayers: [],
+  declarationTurn: 0,
+  needsRedeal: false,
+  soloNapoleon: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+})
+
+const getTeams = (): HTMLElement => {
+  const heading = screen.getByText('Teams')
+  const section = heading.parentElement
+  if (!section) throw new Error('Teams section not found')
+  return section
+}
+
+describe('GameStatus adjutant reveal gate', () => {
+  it('reveals the adjutant in Teams on the finished screen', () => {
+    const gameState = createGameState(GAME_PHASES.FINISHED, false)
+    // 前提: 終了後は正体を公開してよい
+    expect(isAdjutantIdentityPublic(gameState)).toBe(true)
+
+    render(<GameStatus gameState={gameState} currentPlayerId="p3" />)
+
+    const teams = getTeams()
+    const adjutantPill = within(teams).getByText(PLAYER_ROLES.ADJUTANT)
+    const adjutantRow = adjutantPill.parentElement
+    if (!adjutantRow) throw new Error('Adjutant row not found')
+
+    // 副官の名前が役職とともに出る
+    expect(within(adjutantRow).getByText(ADJUTANT_NAME)).toBeInTheDocument()
+    expect(
+      within(teams).queryByText(HIDDEN_ADJUTANT_TEXT)
+    ).not.toBeInTheDocument()
+
+    // 公開済みなので Allied Forces の一覧からは外れる
+    const alliedText = screen.getByText(/Allied Forces:/).textContent ?? ''
+    expect(alliedText).not.toContain(ADJUTANT_NAME)
+  })
+
+  it.each(
+    PRE_REVEAL_PHASES
+  )('keeps the adjutant hidden during the %s phase', (phase) => {
+    const gameState = createGameState(phase, true)
+    // 前提: このフェーズではまだ公開してはいけない
+    expect(isAdjutantIdentityPublic(gameState)).toBe(false)
+
+    render(<GameStatus gameState={gameState} currentPlayerId="p3" />)
+
+    const teams = getTeams()
+    expect(within(teams).getByText(HIDDEN_ADJUTANT_TEXT)).toBeInTheDocument()
+
+    // 副官名が役職行に現れない
+    const adjutantPill = within(teams).getByText(PLAYER_ROLES.ADJUTANT)
+    const adjutantRow = adjutantPill.parentElement
+    if (!adjutantRow) throw new Error('Adjutant row not found')
+    expect(
+      within(adjutantRow).queryByText(ADJUTANT_NAME)
+    ).not.toBeInTheDocument()
+  })
+
+  it('does not show the Teams panel at all while bidding is still open', () => {
+    // #511: 競り中は最高提示者が確定チームに見えてはいけない
+    render(
+      <GameStatus
+        gameState={createGameState(GAME_PHASES.NAPOLEON, true)}
+        currentPlayerId="p3"
+      />
+    )
+
+    expect(screen.queryByText('Teams')).not.toBeInTheDocument()
+    expect(screen.queryByText(ADJUTANT_NAME)).not.toBeInTheDocument()
+  })
+
+  it('does not claim the adjutant was found by a card that was never played', () => {
+    // 早期終了では副官指定カードが場に出ないまま終わる
+    render(
+      <GameStatus
+        gameState={createGameState(GAME_PHASES.FINISHED, false)}
+        currentPlayerId="p3"
+      />
+    )
+
+    expect(
+      screen.queryByText(new RegExp(`${PLAYER_ROLES.ADJUTANT} was found by`))
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/game/GameStatus.adjutantRevealGate.test.tsx
+++ b/tests/components/game/GameStatus.adjutantRevealGate.test.tsx
@@ -122,26 +122,27 @@ describe('GameStatus adjutant reveal gate', () => {
     expect(alliedText).not.toContain(ADJUTANT_NAME)
   })
 
-  it.each(
-    PRE_REVEAL_PHASES
-  )('keeps the adjutant hidden during the %s phase', (phase) => {
-    const gameState = createGameState(phase, true)
-    // 前提: このフェーズではまだ公開してはいけない
-    expect(isAdjutantIdentityPublic(gameState)).toBe(false)
+  it.each(PRE_REVEAL_PHASES)(
+    'keeps the adjutant hidden during the %s phase',
+    (phase) => {
+      const gameState = createGameState(phase, true)
+      // 前提: このフェーズではまだ公開してはいけない
+      expect(isAdjutantIdentityPublic(gameState)).toBe(false)
 
-    render(<GameStatus gameState={gameState} currentPlayerId="p3" />)
+      render(<GameStatus gameState={gameState} currentPlayerId="p3" />)
 
-    const teams = getTeams()
-    expect(within(teams).getByText(HIDDEN_ADJUTANT_TEXT)).toBeInTheDocument()
+      const teams = getTeams()
+      expect(within(teams).getByText(HIDDEN_ADJUTANT_TEXT)).toBeInTheDocument()
 
-    // 副官名が役職行に現れない
-    const adjutantPill = within(teams).getByText(PLAYER_ROLES.ADJUTANT)
-    const adjutantRow = adjutantPill.parentElement
-    if (!adjutantRow) throw new Error('Adjutant row not found')
-    expect(
-      within(adjutantRow).queryByText(ADJUTANT_NAME)
-    ).not.toBeInTheDocument()
-  })
+      // 副官名が役職行に現れない
+      const adjutantPill = within(teams).getByText(PLAYER_ROLES.ADJUTANT)
+      const adjutantRow = adjutantPill.parentElement
+      if (!adjutantRow) throw new Error('Adjutant row not found')
+      expect(
+        within(adjutantRow).queryByText(ADJUTANT_NAME)
+      ).not.toBeInTheDocument()
+    }
+  )
 
   it('does not show the Teams panel at all while bidding is still open', () => {
     // #511: 競り中は最高提示者が確定チームに見えてはいけない

--- a/tests/components/game/GameStatus.declarationLabel.test.tsx
+++ b/tests/components/game/GameStatus.declarationLabel.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * 宣言数のラベル不変条件テスト
+ *
+ * `NapoleonDeclaration.targetTricks` は名前に反して「絵札数」を表す。
+ * 宣言数を描画する画面は、必ず絵札（face cards）と分かる単位で出すこと。
+ * トリック数（12 トリック）と取り違えられる表記を出してはいけない。
+ */
+
+import { render, screen, within } from '@testing-library/react'
+import { AdjutantSelector } from '@/components/game/AdjutantSelector'
+import { DeclarationDisplay } from '@/components/game/DeclarationDisplay'
+import { GameStatus } from '@/components/game/GameStatus'
+import {
+  CARD_RANKS,
+  DECLARATION_LABELS,
+  GAME_PHASES,
+  SUIT_ENUM,
+} from '@/lib/constants'
+import type { Card, GameState, Player } from '@/types/game'
+
+const TARGET_FACE_CARDS = 15
+const NAPOLEON_ID = 'nap'
+
+/** トリック数と取り違えられる単位表記 */
+const TRICK_UNIT_PATTERN = /\btricks?\b/i
+
+const adjutantCard: Card = {
+  id: 'adjutant-card',
+  suit: SUIT_ENUM.HEARTS,
+  rank: CARD_RANKS.KING,
+  value: 13,
+}
+
+const createPlayer = (id: string, overrides: Partial<Player> = {}): Player => ({
+  id,
+  name: `${id} player`,
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  position: 1,
+  isAI: false,
+  ...overrides,
+})
+
+const createGameState = (): GameState => ({
+  id: 'declaration-label-test',
+  players: [
+    createPlayer(NAPOLEON_ID, { isNapoleon: true }),
+    createPlayer('p2'),
+    createPlayer('p3'),
+    createPlayer('p4'),
+  ],
+  phase: GAME_PHASES.ADJUTANT,
+  currentPlayerIndex: 0,
+  currentTrick: { id: 'current', cards: [], completed: false },
+  tricks: [],
+  hiddenCards: [],
+  napoleonCard: adjutantCard,
+  trumpSuit: SUIT_ENUM.SPADES,
+  napoleonDeclaration: {
+    playerId: NAPOLEON_ID,
+    targetTricks: TARGET_FACE_CARDS,
+    suit: SUIT_ENUM.SPADES,
+    adjutantCard,
+  },
+  passedPlayers: [],
+  declarationTurn: 0,
+  needsRedeal: false,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+})
+
+/** 見出しを持つセクション（見出しの親要素）を取得する */
+const getSection = (headingText: string): HTMLElement => {
+  const heading = screen.getByText(headingText)
+  const section = heading.parentElement
+  if (!section) throw new Error(`Section not found: ${headingText}`)
+  return section
+}
+
+describe('declared count is labelled as face cards', () => {
+  it('labels the GameStatus declaration block with face cards, not tricks', () => {
+    render(<GameStatus gameState={createGameState()} />)
+
+    const section = getSection('Napoleon Declaration')
+    expect(section).toHaveTextContent(String(TARGET_FACE_CARDS))
+    expect(
+      within(section).getByText(DECLARATION_LABELS.FACE_CARDS)
+    ).toBeInTheDocument()
+    expect(section.textContent ?? '').not.toMatch(TRICK_UNIT_PATTERN)
+  })
+
+  it('labels the AdjutantSelector declaration block with face cards, not tricks', () => {
+    render(
+      <AdjutantSelector
+        gameState={createGameState()}
+        napoleonPlayerId={NAPOLEON_ID}
+        onAdjutantSelect={() => {}}
+      />
+    )
+
+    const section = getSection('Your Napoleon Declaration')
+    expect(section).toHaveTextContent(String(TARGET_FACE_CARDS))
+    expect(
+      within(section).getByText(DECLARATION_LABELS.FACE_CARDS)
+    ).toBeInTheDocument()
+    expect(section.textContent ?? '').not.toMatch(TRICK_UNIT_PATTERN)
+  })
+
+  it('labels the DeclarationDisplay block with face cards, not tricks', () => {
+    const { container } = render(
+      <DeclarationDisplay
+        declaration={{
+          playerId: NAPOLEON_ID,
+          targetTricks: TARGET_FACE_CARDS,
+          suit: SUIT_ENUM.SPADES,
+        }}
+      />
+    )
+
+    expect(container).toHaveTextContent(String(TARGET_FACE_CARDS))
+    expect(screen.getByText(DECLARATION_LABELS.FACE_CARDS)).toBeInTheDocument()
+    expect(container.textContent ?? '').not.toMatch(TRICK_UNIT_PATTERN)
+  })
+})

--- a/tests/components/game/GameStatus.solo-napoleon.test.tsx
+++ b/tests/components/game/GameStatus.solo-napoleon.test.tsx
@@ -6,15 +6,27 @@
  * - 公開後はナポレオン本人に Napoleon と Adjutant の両方を出す
  * - Teams パネルでナポレオンが 2 行に重複しない / Allied Forces に混ざらない
  * - 通常ゲームの表示は従来どおり
+ *
+ * ⚠️ 描画されるフェーズだけで検証すること。
+ * GameStatus は PLAYING では描画されない（page.tsx の PLAYING 専用レイアウトは
+ * TopHUD だけを出す）。以前はこのテストが phase: PLAYING で
+ * 「Face Cards Won by Player」セクションの N/A バッジを見ていたが、
+ * そのセクションごとアプリ上に存在しなかったため検証が空回りしていた。
+ * 実際に描画されるのは競り後の準備フェーズ（ADJUTANT / EXCHANGE）と
+ * 終了画面（FINISHED）なので、公開前後をこの 2 つで表現する。
  */
 
 import { render, screen, within } from '@testing-library/react'
 import { GameStatus } from '@/components/game/GameStatus'
-import { GAME_PHASES, PLAYER_ROLES } from '@/lib/constants'
-import type { Card, GameState, Player, Trick } from '@/types/game'
+import {
+  GAME_PHASES,
+  PLAYER_ROLES,
+  SOLO_NAPOLEON_LABELS,
+} from '@/lib/constants'
+import type { Card, GameState, Player } from '@/types/game'
 
 // rank は K を使う。A にすると「A of hearts」等の本文と
-// 副官バッジの "A" がテキスト検索で衝突するため
+// 役職ピルのテキスト検索が衝突するため
 const adjutantCard: Card = {
   id: 'adjutant-card',
   suit: 'hearts',
@@ -23,8 +35,9 @@ const adjutantCard: Card = {
 }
 
 const NAPOLEON_NAME = 'Napoleon Player'
-const ADJUTANT_BADGE_TEXT = 'A'
-const NAPOLEON_BADGE_TEXT = 'N'
+const ADJUTANT_NAME = 'Second Player'
+const HIDDEN_ADJUTANT_TEXT = '??? (Hidden)'
+const HIDDEN_ADJUTANT_NOTE = /includes hidden adjutant/
 
 const createPlayer = (
   id: string,
@@ -41,30 +54,16 @@ const createPlayer = (
   ...overrides,
 })
 
-/** ナポレオンが埋め札の副官カードを出したトリック（= 公開済み） */
-const revealingTrick: Trick = {
-  id: 'trick-reveal',
-  completed: true,
-  winnerPlayerId: 'nap',
-  cards: [
-    {
-      card: { ...adjutantCard, wasHidden: true },
-      playerId: 'nap',
-      order: 0,
-      revealsAdjutant: true,
-    },
-  ],
-}
-
 const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
   id: 'test-game',
   players: [
     createPlayer('nap', NAPOLEON_NAME, { isNapoleon: true }),
-    createPlayer('p2', 'Second Player'),
+    createPlayer('p2', ADJUTANT_NAME),
     createPlayer('p3', 'Third Player'),
     createPlayer('p4', 'Fourth Player'),
   ],
-  phase: GAME_PHASES.PLAYING,
+  // 副官の正体がまだ伏せられている、実際に GameStatus が描画されるフェーズ
+  phase: GAME_PHASES.EXCHANGE,
   currentPlayerIndex: 0,
   currentTrick: { id: 'trick-1', cards: [], completed: false },
   tricks: [],
@@ -85,6 +84,10 @@ const createGameState = (overrides: Partial<GameState> = {}): GameState => ({
   ...overrides,
 })
 
+/** 終了画面（= 副官の正体が公開されるフェーズ）の state */
+const createFinishedState = (overrides: Partial<GameState> = {}): GameState =>
+  createGameState({ phase: GAME_PHASES.FINISHED, ...overrides })
+
 /** 見出しを持つセクション（見出しの親要素）を取得する */
 const getSection = (headingText: string): HTMLElement => {
   const heading = screen.getByText(headingText)
@@ -93,17 +96,18 @@ const getSection = (headingText: string): HTMLElement => {
   return section
 }
 
-/** "Face Cards Won by Player" 一覧から指定プレイヤーの行を取得する */
-const getPlayerRow = (playerName: string): HTMLElement => {
-  const section = getSection('Face Cards Won by Player')
-  const nameSpan = within(section).getByText(playerName)
-  const row = nameSpan.parentElement
-  if (!row) throw new Error(`Player row not found: ${playerName}`)
+const getTeams = (): HTMLElement => getSection('Teams')
+
+/** Teams パネル内で、指定した役職ピルと同じ行（親要素）を返す */
+const getRoleRow = (roleLabel: string): HTMLElement => {
+  const pill = within(getTeams()).getByText(roleLabel)
+  const row = pill.parentElement
+  if (!row) throw new Error(`Role row not found: ${roleLabel}`)
   return row
 }
 
 describe('GameStatus - solo napoleon badges', () => {
-  it('shows no adjutant badge before the buried card is played', () => {
+  it('shows no adjutant badge before the game is finished', () => {
     // マスク済み状態を模す: 未公開の閲覧者には soloNapoleon が届かない
     render(
       <GameStatus
@@ -112,16 +116,23 @@ describe('GameStatus - solo napoleon badges', () => {
       />
     )
 
-    // 副官は「??? (Hidden)」のまま。誰にも A バッジは付かない
-    expect(screen.getByText('??? (Hidden)')).toBeInTheDocument()
-    const section = getSection('Face Cards Won by Player')
+    const teams = getTeams()
+    // 副官は「??? (Hidden)」のまま
+    expect(within(teams).getByText(HIDDEN_ADJUTANT_TEXT)).toBeInTheDocument()
+    // ソロであることも伏せられている
     expect(
-      within(section).queryByText(ADJUTANT_BADGE_TEXT)
+      within(teams).queryByText(SOLO_NAPOLEON_LABELS.BADGE)
+    ).not.toBeInTheDocument()
+    // ナポレオンの行に Adjutant ピルは付かない
+    expect(
+      within(getRoleRow(PLAYER_ROLES.NAPOLEON)).queryByText(
+        PLAYER_ROLES.ADJUTANT
+      )
     ).not.toBeInTheDocument()
   })
 
   it('shows no adjutant badge to Napoleon either before the reveal', () => {
-    // ナポレオン本人は soloNapoleon を受け取るが、公開前は出さない
+    // ナポレオン本人は soloNapoleon を受け取るが、公開前は A を出さない
     render(
       <GameStatus
         gameState={createGameState({ soloNapoleon: true })}
@@ -129,70 +140,57 @@ describe('GameStatus - solo napoleon badges', () => {
       />
     )
 
-    const section = getSection('Face Cards Won by Player')
     expect(
-      within(section).queryByText(ADJUTANT_BADGE_TEXT)
+      within(getRoleRow(PLAYER_ROLES.NAPOLEON)).queryByText(
+        PLAYER_ROLES.ADJUTANT
+      )
     ).not.toBeInTheDocument()
   })
 
-  it('gives Napoleon both the N and A badges after the reveal', () => {
+  it('gives Napoleon both the Napoleon and Adjutant pills after the reveal', () => {
     render(
       <GameStatus
-        gameState={createGameState({
-          soloNapoleon: true,
-          tricks: [revealingTrick],
-        })}
+        gameState={createFinishedState({ soloNapoleon: true })}
         currentPlayerId="p2"
       />
     )
 
-    const napoleonRow = getPlayerRow(NAPOLEON_NAME)
+    // 同じ行に Napoleon と Adjutant のピルが並ぶ
+    const napoleonRow = getRoleRow(PLAYER_ROLES.NAPOLEON)
     expect(
-      within(napoleonRow).getByText(NAPOLEON_BADGE_TEXT)
+      within(napoleonRow).getByText(PLAYER_ROLES.ADJUTANT)
     ).toBeInTheDocument()
-    expect(
-      within(napoleonRow).getByText(ADJUTANT_BADGE_TEXT)
-    ).toBeInTheDocument()
+    expect(within(napoleonRow).getByText(NAPOLEON_NAME)).toBeInTheDocument()
 
-    // A バッジは一覧全体で 1 つだけ = 他プレイヤーには付いていない
-    const section = getSection('Face Cards Won by Player')
-    expect(within(section).getAllByText(ADJUTANT_BADGE_TEXT)).toHaveLength(1)
+    // Adjutant ピルは Teams 全体で 1 つだけ = 他プレイヤーには付いていない
+    expect(within(getTeams()).getAllByText(PLAYER_ROLES.ADJUTANT)).toHaveLength(
+      1
+    )
   })
 
   it('does not duplicate Napoleon in the Teams panel after the reveal', () => {
     render(
       <GameStatus
-        gameState={createGameState({
-          soloNapoleon: true,
-          tricks: [revealingTrick],
-        })}
+        gameState={createFinishedState({ soloNapoleon: true })}
         currentPlayerId="p2"
       />
     )
 
-    const teams = getSection('Teams')
+    const teams = getTeams()
 
     // ナポレオン名は Teams パネル内で 1 回だけ（副官用の行が増えない）
     expect(within(teams).getAllByText(NAPOLEON_NAME)).toHaveLength(1)
 
-    // 同じ行に Napoleon と Adjutant のピルが並ぶ
-    const napoleonPill = within(teams).getByText(PLAYER_ROLES.NAPOLEON)
-    const row = napoleonPill.parentElement
-    if (!row) throw new Error('Napoleon team row not found')
-    expect(within(row).getByText(PLAYER_ROLES.ADJUTANT)).toBeInTheDocument()
-    expect(within(row).getByText(NAPOLEON_NAME)).toBeInTheDocument()
-
     // 「??? (Hidden)」は消えている
-    expect(within(teams).queryByText('??? (Hidden)')).not.toBeInTheDocument()
+    expect(
+      within(teams).queryByText(HIDDEN_ADJUTANT_TEXT)
+    ).not.toBeInTheDocument()
   })
 
   it('keeps Napoleon out of the Allied Forces list in a solo game', () => {
     render(
       <GameStatus
-        gameState={createGameState({
-          soloNapoleon: true,
-          tricks: [revealingTrick],
-        })}
+        gameState={createFinishedState({ soloNapoleon: true })}
         currentPlayerId="p2"
       />
     )
@@ -200,69 +198,74 @@ describe('GameStatus - solo napoleon badges', () => {
     const alliedLine = screen.getByText(/Allied Forces:/)
     const text = alliedLine.textContent ?? ''
 
-    expect(text).toContain('Second Player')
+    expect(text).toContain(ADJUTANT_NAME)
     expect(text).toContain('Third Player')
     expect(text).toContain('Fourth Player')
     expect(text).not.toContain(NAPOLEON_NAME)
     // 存在しない副官を待たせる文言を出さない
-    expect(text).not.toContain('includes hidden adjutant')
+    expect(text).not.toMatch(HIDDEN_ADJUTANT_NOTE)
   })
 })
 
 describe('GameStatus - normal game is unchanged', () => {
-  const normalState = (overrides: Partial<GameState> = {}) =>
-    createGameState({
-      soloNapoleon: false,
-      players: [
-        createPlayer('nap', NAPOLEON_NAME, { isNapoleon: true }),
-        createPlayer('p2', 'Second Player', { isAdjutant: true }),
-        createPlayer('p3', 'Third Player'),
-        createPlayer('p4', 'Fourth Player'),
-      ],
-      ...overrides,
-    })
+  /** 実在する副官がいる通常ゲーム */
+  const normalPlayers = (): Player[] => [
+    createPlayer('nap', NAPOLEON_NAME, { isNapoleon: true }),
+    createPlayer('p2', ADJUTANT_NAME, { isAdjutant: true }),
+    createPlayer('p3', 'Third Player'),
+    createPlayer('p4', 'Fourth Player'),
+  ]
 
   it('still hides the adjutant before the designation card is played', () => {
-    render(<GameStatus gameState={normalState()} currentPlayerId="p3" />)
-
-    expect(screen.getByText('??? (Hidden)')).toBeInTheDocument()
-    const section = getSection('Face Cards Won by Player')
-    expect(
-      within(section).queryByText(ADJUTANT_BADGE_TEXT)
-    ).not.toBeInTheDocument()
-    expect(screen.getByText(/includes hidden adjutant/)).toBeInTheDocument()
-  })
-
-  it('shows the A badge on the real adjutant only, after the reveal', () => {
-    const revealedByAdjutant: Trick = {
-      id: 'trick-a',
-      completed: true,
-      winnerPlayerId: 'p2',
-      cards: [{ card: adjutantCard, playerId: 'p2', order: 0 }],
-    }
-
+    // maskGameStateForPlayer は未公開の閲覧者へ isAdjutant: false で渡す
     render(
       <GameStatus
-        gameState={normalState({ tricks: [revealedByAdjutant] })}
+        gameState={createGameState({
+          soloNapoleon: false,
+          players: normalPlayers().map((player) => ({
+            ...player,
+            isAdjutant: false,
+          })),
+        })}
         currentPlayerId="p3"
       />
     )
 
-    const adjutantRow = getPlayerRow('Second Player')
+    const teams = getTeams()
+    expect(within(teams).getByText(HIDDEN_ADJUTANT_TEXT)).toBeInTheDocument()
+    expect(within(teams).getByText(HIDDEN_ADJUTANT_NOTE)).toBeInTheDocument()
+    // 副官名が役職として示されていない
     expect(
-      within(adjutantRow).getByText(ADJUTANT_BADGE_TEXT)
+      within(getRoleRow(PLAYER_ROLES.ADJUTANT)).queryByText(ADJUTANT_NAME)
+    ).not.toBeInTheDocument()
+  })
+
+  it('names the real adjutant only, after the reveal', () => {
+    render(
+      <GameStatus
+        gameState={createFinishedState({
+          soloNapoleon: false,
+          players: normalPlayers(),
+        })}
+        currentPlayerId="p3"
+      />
+    )
+
+    // Adjutant ピルの行に副官の名前が出る
+    expect(
+      within(getRoleRow(PLAYER_ROLES.ADJUTANT)).getByText(ADJUTANT_NAME)
     ).toBeInTheDocument()
 
-    // ナポレオンには N のみ、A は付かない
-    const napoleonRow = getPlayerRow(NAPOLEON_NAME)
+    // ナポレオンの行には Adjutant ピルが付かない
     expect(
-      within(napoleonRow).getByText(NAPOLEON_BADGE_TEXT)
-    ).toBeInTheDocument()
-    expect(
-      within(napoleonRow).queryByText(ADJUTANT_BADGE_TEXT)
+      within(getRoleRow(PLAYER_ROLES.NAPOLEON)).queryByText(
+        PLAYER_ROLES.ADJUTANT
+      )
     ).not.toBeInTheDocument()
 
-    const section = getSection('Face Cards Won by Player')
-    expect(within(section).getAllByText(ADJUTANT_BADGE_TEXT)).toHaveLength(1)
+    // Adjutant ピルは Teams 全体で 1 つだけ
+    expect(within(getTeams()).getAllByText(PLAYER_ROLES.ADJUTANT)).toHaveLength(
+      1
+    )
   })
 })

--- a/tests/components/game/TopHUD.declaration.test.tsx
+++ b/tests/components/game/TopHUD.declaration.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * TopHUD の宣言（絵札数）視認性テスト
+ *
+ * 文言の完全一致ではなく、次の不変条件だけを検証する:
+ * - 宣言した絵札数が HUD に出ていること（トリック数と取り違えられない表記であること）
+ * - 「あと何枚必要か」が両陣営分、宣言と獲得枚数から導かれた値で出ること
+ * - 目標に届いている side には「あと 0 枚」ではなく達成表記が出ること
+ */
+
+import { render, screen } from '@testing-library/react'
+import { TopHUD } from '@/components/game/TopHUD'
+import {
+  CARD_RANKS,
+  DECLARATION_LABELS,
+  GAME_PHASES,
+  NAPOLEON_RULES,
+  PLAYER_ROLES,
+  SUIT_ENUM,
+} from '@/lib/constants'
+import { getGameProgress } from '@/lib/scoring'
+import type { Card, GameState, Player, Trick } from '@/types/game'
+
+const NAPOLEON_ID = 'nap'
+const CITIZEN_ID = 'cit'
+
+const createPlayer = (id: string, overrides: Partial<Player> = {}): Player => ({
+  id,
+  name: `${id} player`,
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  position: 1,
+  isAI: false,
+  ...overrides,
+})
+
+/** 絵札 1 枚だけを含む獲得済みトリック */
+const createFaceCardTrick = (index: number, winnerPlayerId: string): Trick => {
+  const card: Card = {
+    id: `face-${index}`,
+    suit: SUIT_ENUM.SPADES,
+    rank: CARD_RANKS.KING,
+    value: 13,
+  }
+  return {
+    id: `trick-${index}`,
+    completed: true,
+    winnerPlayerId,
+    cards: [{ card, playerId: winnerPlayerId, order: 0 }],
+  }
+}
+
+const createGameState = ({
+  targetTricks,
+  napoleonFaceCards,
+  citizenFaceCards,
+}: {
+  targetTricks: number
+  napoleonFaceCards: number
+  citizenFaceCards: number
+}): GameState => {
+  const tricks: Trick[] = []
+  for (let i = 0; i < napoleonFaceCards; i++) {
+    tricks.push(createFaceCardTrick(tricks.length, NAPOLEON_ID))
+  }
+  for (let i = 0; i < citizenFaceCards; i++) {
+    tricks.push(createFaceCardTrick(tricks.length, CITIZEN_ID))
+  }
+
+  return {
+    id: 'hud-declaration-test',
+    players: [
+      createPlayer(NAPOLEON_ID, { isNapoleon: true }),
+      createPlayer('adj'),
+      createPlayer(CITIZEN_ID),
+      createPlayer('cit2'),
+    ],
+    phase: GAME_PHASES.PLAYING,
+    currentPlayerIndex: 0,
+    currentTrick: { id: 'current', cards: [], completed: false },
+    tricks,
+    hiddenCards: [],
+    // ロゴが常に ♠ を描画するため、切り札は ♦ にして表示の衝突を避ける
+    trumpSuit: SUIT_ENUM.DIAMONDS,
+    napoleonDeclaration: {
+      playerId: NAPOLEON_ID,
+      targetTricks,
+      suit: SUIT_ENUM.DIAMONDS,
+    },
+    passedPlayers: [],
+    declarationTurn: 0,
+    needsRedeal: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+}
+
+/** 「<verb> <count> more」が HUD 内のどこかに現れることを表すパターン */
+const remainingPattern = (verb: string, count: number) =>
+  new RegExp(`${verb}\\s+${count}\\s+${DECLARATION_LABELS.MORE}`)
+
+/**
+ * 指定した断片をすべて含む最も内側の <span> を返す。
+ * getByText は直下のテキストノードしか見ないため、<b> を挟む行は拾えない。
+ * ここでは textContent を使い、祖先を除外して「1 行」を特定する
+ */
+const findLine = (...fragments: (string | RegExp)[]): HTMLElement => {
+  const matches = Array.from(
+    document.body.querySelectorAll<HTMLElement>('span')
+  ).filter((element) => {
+    const text = (element.textContent ?? '').replace(/\s+/g, ' ')
+    return fragments.every((fragment) =>
+      typeof fragment === 'string'
+        ? text.includes(fragment)
+        : fragment.test(text)
+    )
+  })
+  const innermost = matches.filter(
+    (element) =>
+      !matches.some((other) => other !== element && element.contains(other))
+  )
+  if (innermost.length !== 1 || !innermost[0]) {
+    throw new Error(`Expected exactly one line, found ${innermost.length}`)
+  }
+  return innermost[0]
+}
+
+describe('TopHUD declaration visibility', () => {
+  it('shows the declared face card count labelled as face cards, not tricks', () => {
+    const gameState = createGameState({
+      targetTricks: 15,
+      napoleonFaceCards: 0,
+      citizenFaceCards: 0,
+    })
+
+    render(<TopHUD gameState={gameState} currentPlayerId={CITIZEN_ID} />)
+
+    // 宣言枚数そのものが独立した見出し付きチップとして出ている
+    const declaredLabel = screen.getByText(DECLARATION_LABELS.DECLARED)
+    const chip = declaredLabel.parentElement
+    expect(chip).not.toBeNull()
+    // 宣言枚数と「絵札」の単位が必ず同じチップ内に並ぶ
+    expect(chip).toHaveTextContent('15')
+    expect(chip).toHaveTextContent(DECLARATION_LABELS.FACE_CARDS)
+  })
+
+  it('omits the declaration chip when nobody has declared yet', () => {
+    const gameState = createGameState({
+      targetTricks: 15,
+      napoleonFaceCards: 0,
+      citizenFaceCards: 0,
+    })
+
+    render(
+      <TopHUD
+        gameState={{ ...gameState, napoleonDeclaration: undefined }}
+        currentPlayerId={CITIZEN_ID}
+      />
+    )
+
+    expect(
+      screen.queryByText(DECLARATION_LABELS.DECLARED)
+    ).not.toBeInTheDocument()
+  })
+
+  it('shows how many more face cards each side needs, derived from the declaration', () => {
+    const gameState = createGameState({
+      targetTricks: 15,
+      napoleonFaceCards: 8,
+      citizenFaceCards: 2,
+    })
+    const progress = getGameProgress(gameState)
+
+    const { container } = render(
+      <TopHUD gameState={gameState} currentPlayerId={CITIZEN_ID} />
+    )
+
+    // 前提: ナポレオンは 15 - 8 = 7 枚、連合軍は (20 - 15 + 1) - 2 = 4 枚必要
+    expect(progress.napoleonNeedsToWin).toBe(7)
+    expect(progress.allianceNeedsToWin).toBe(4)
+
+    expect(container).toHaveTextContent(
+      remainingPattern(DECLARATION_LABELS.NEEDS, progress.napoleonNeedsToWin)
+    )
+    expect(container).toHaveTextContent(
+      remainingPattern(DECLARATION_LABELS.NEED, progress.allianceNeedsToWin)
+    )
+  })
+
+  it('recomputes the remaining counts when the declaration changes', () => {
+    const low = createGameState({
+      targetTricks: 13,
+      napoleonFaceCards: 5,
+      citizenFaceCards: 0,
+    })
+    const { container, rerender } = render(
+      <TopHUD gameState={low} currentPlayerId={CITIZEN_ID} />
+    )
+    expect(container).toHaveTextContent(
+      remainingPattern(DECLARATION_LABELS.NEEDS, 13 - 5)
+    )
+
+    const high = createGameState({
+      targetTricks: 18,
+      napoleonFaceCards: 5,
+      citizenFaceCards: 0,
+    })
+    rerender(<TopHUD gameState={high} currentPlayerId={CITIZEN_ID} />)
+    expect(container).toHaveTextContent(
+      remainingPattern(DECLARATION_LABELS.NEEDS, 18 - 5)
+    )
+  })
+
+  it('replaces "0 more" with an explicit met/blocked label', () => {
+    const napoleonDone = createGameState({
+      targetTricks: 13,
+      napoleonFaceCards: 13,
+      citizenFaceCards: 0,
+    })
+    const { container } = render(
+      <TopHUD gameState={napoleonDone} currentPlayerId={NAPOLEON_ID} />
+    )
+
+    expect(container).not.toHaveTextContent(
+      remainingPattern(DECLARATION_LABELS.NEEDS, 0)
+    )
+    expect(
+      screen.getByText(DECLARATION_LABELS.NAPOLEON_MET)
+    ).toBeInTheDocument()
+  })
+
+  it('keeps both teams face card counts visible next to their remaining counts', () => {
+    const gameState = createGameState({
+      targetTricks: 15,
+      napoleonFaceCards: 6,
+      citizenFaceCards: 3,
+    })
+
+    render(<TopHUD gameState={gameState} currentPlayerId={CITIZEN_ID} />)
+
+    // ナポレオン行: 獲得 6 枚と「あと 9 枚」が同じ行に並ぶ
+    const napoleonLine = findLine(
+      PLAYER_ROLES.NAPOLEON,
+      remainingPattern(DECLARATION_LABELS.NEEDS, 15 - 6)
+    )
+    expect(napoleonLine.textContent).toMatch(/\b6\b/)
+
+    // 連合軍行: 獲得 3 枚と「阻止まであと何枚」が同じ行に並ぶ
+    const allianceRemaining = NAPOLEON_RULES.TOTAL_FACE_CARDS - 15 + 1 - 3
+    const allianceLine = findLine(
+      PLAYER_ROLES.ALLIED_FORCES,
+      remainingPattern(DECLARATION_LABELS.NEED, allianceRemaining)
+    )
+    expect(allianceLine.textContent).toMatch(/\b3\b/)
+  })
+})

--- a/tests/lib/scoring.declarationProgress.test.ts
+++ b/tests/lib/scoring.declarationProgress.test.ts
@@ -133,41 +133,39 @@ describe('getGameProgress remaining face cards', () => {
     expect(allianceOvershoot.allianceNeedsToWin).toBe(0)
   })
 
-  it.each([
-    13,
-    15,
-    18,
-    NAPOLEON_RULES.TOTAL_FACE_CARDS,
-  ])('reports an alliance remaining count consistent with isGameDecided (target %i)', (targetTricks) => {
-    const blockingTotal = NAPOLEON_RULES.TOTAL_FACE_CARDS - targetTricks + 1
-    const alreadyWon = Math.max(0, blockingTotal - 2)
+  it.each([13, 15, 18, NAPOLEON_RULES.TOTAL_FACE_CARDS])(
+    'reports an alliance remaining count consistent with isGameDecided (target %i)',
+    (targetTricks) => {
+      const blockingTotal = NAPOLEON_RULES.TOTAL_FACE_CARDS - targetTricks + 1
+      const alreadyWon = Math.max(0, blockingTotal - 2)
 
-    const state = createGameState({
-      targetTricks,
-      napoleonFaceCards: 0,
-      citizenFaceCards: alreadyWon,
-    })
-    const progress = getGameProgress(state)
+      const state = createGameState({
+        targetTricks,
+        napoleonFaceCards: 0,
+        citizenFaceCards: alreadyWon,
+      })
+      const progress = getGameProgress(state)
 
-    // 不変条件: 残り枚数ちょうどを取れば阻止が確定し、1 枚足りなければ未確定
-    expect(progress.allianceNeedsToWin).toBeGreaterThan(0)
+      // 不変条件: 残り枚数ちょうどを取れば阻止が確定し、1 枚足りなければ未確定
+      expect(progress.allianceNeedsToWin).toBeGreaterThan(0)
 
-    const oneShort = createGameState({
-      targetTricks,
-      napoleonFaceCards: 0,
-      citizenFaceCards: alreadyWon + progress.allianceNeedsToWin - 1,
-    })
-    expect(isGameDecided(oneShort).decided).toBe(false)
+      const oneShort = createGameState({
+        targetTricks,
+        napoleonFaceCards: 0,
+        citizenFaceCards: alreadyWon + progress.allianceNeedsToWin - 1,
+      })
+      expect(isGameDecided(oneShort).decided).toBe(false)
 
-    const exact = createGameState({
-      targetTricks,
-      napoleonFaceCards: 0,
-      citizenFaceCards: alreadyWon + progress.allianceNeedsToWin,
-    })
-    const decided = isGameDecided(exact)
-    expect(decided.decided).toBe(true)
-    expect(decided.napoleonWon).toBe(false)
-  })
+      const exact = createGameState({
+        targetTricks,
+        napoleonFaceCards: 0,
+        citizenFaceCards: alreadyWon + progress.allianceNeedsToWin,
+      })
+      const decided = isGameDecided(exact)
+      expect(decided.decided).toBe(true)
+      expect(decided.napoleonWon).toBe(false)
+    }
+  )
 
   it('shrinks the alliance remaining count as they take more face cards', () => {
     const before = getGameProgress(

--- a/tests/lib/scoring.declarationProgress.test.ts
+++ b/tests/lib/scoring.declarationProgress.test.ts
@@ -1,0 +1,190 @@
+/**
+ * getGameProgress の「あと何枚必要か」不変条件テスト
+ *
+ * 表示文言ではなく数値の関係だけを検証する。
+ * - ナポレオン側: 宣言枚数 - 獲得枚数（下限 0）
+ * - 連合軍側: 阻止が確定する最小枚数 - 獲得枚数（下限 0）
+ *   連合軍の勝利条件は isGameDecided と同じ「TOTAL - 宣言 を超えること」なので、
+ *   両者が食い違わないことを isGameDecided と突き合わせて確認する
+ */
+
+import {
+  CARD_RANKS,
+  countFaceCards,
+  GAME_PHASES,
+  NAPOLEON_RULES,
+  SUIT_ENUM,
+} from '@/lib/constants'
+import { getGameProgress, isGameDecided } from '@/lib/scoring'
+import type { Card, GameState, Player, Trick } from '@/types/game'
+
+const NAPOLEON_ID = 'nap'
+const ADJUTANT_ID = 'adj'
+const CITIZEN_ID = 'cit'
+
+const createPlayer = (id: string, overrides: Partial<Player> = {}): Player => ({
+  id,
+  name: id,
+  hand: [],
+  isNapoleon: false,
+  isAdjutant: false,
+  position: 1,
+  isAI: false,
+  ...overrides,
+})
+
+/** 絵札 1 枚だけを含むトリック。winnerPlayerId で獲得チームを決める */
+const createFaceCardTrick = (index: number, winnerPlayerId: string): Trick => {
+  const card: Card = {
+    id: `face-${index}`,
+    suit: SUIT_ENUM.SPADES,
+    rank: CARD_RANKS.KING,
+    value: 13,
+  }
+  // 前提確認: このカードは絵札として数えられる
+  expect(countFaceCards([card])).toBe(1)
+
+  return {
+    id: `trick-${index}`,
+    completed: true,
+    winnerPlayerId,
+    cards: [{ card, playerId: winnerPlayerId, order: 0 }],
+  }
+}
+
+/** ナポレオン側 / 連合軍側がそれぞれ指定枚数の絵札を取った状態を作る */
+const createGameState = ({
+  targetTricks,
+  napoleonFaceCards,
+  citizenFaceCards,
+}: {
+  targetTricks: number
+  napoleonFaceCards: number
+  citizenFaceCards: number
+}): GameState => {
+  const tricks: Trick[] = []
+  for (let i = 0; i < napoleonFaceCards; i++) {
+    tricks.push(createFaceCardTrick(tricks.length, NAPOLEON_ID))
+  }
+  for (let i = 0; i < citizenFaceCards; i++) {
+    tricks.push(createFaceCardTrick(tricks.length, CITIZEN_ID))
+  }
+
+  return {
+    id: 'progress-test',
+    players: [
+      createPlayer(NAPOLEON_ID, { isNapoleon: true }),
+      createPlayer(ADJUTANT_ID, { isAdjutant: true }),
+      createPlayer(CITIZEN_ID),
+      createPlayer('cit2'),
+    ],
+    phase: GAME_PHASES.PLAYING,
+    currentPlayerIndex: 0,
+    currentTrick: { id: 'current', cards: [], completed: false },
+    tricks,
+    hiddenCards: [],
+    trumpSuit: SUIT_ENUM.SPADES,
+    napoleonDeclaration: {
+      playerId: NAPOLEON_ID,
+      targetTricks,
+      suit: SUIT_ENUM.SPADES,
+    },
+    passedPlayers: [],
+    declarationTurn: 0,
+    needsRedeal: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  }
+}
+
+describe('getGameProgress remaining face cards', () => {
+  it('reports Napoleon remaining as declaration minus cards already won', () => {
+    const state = createGameState({
+      targetTricks: 15,
+      napoleonFaceCards: 8,
+      citizenFaceCards: 0,
+    })
+
+    const progress = getGameProgress(state)
+
+    expect(progress.napoleonTeamFaceCards).toBe(8)
+    expect(progress.napoleonNeedsToWin).toBe(15 - 8)
+  })
+
+  it('clamps each side to zero instead of going negative', () => {
+    // ナポレオン側が宣言を超えて取った場合
+    const napoleonOvershoot = getGameProgress(
+      createGameState({
+        targetTricks: 13,
+        napoleonFaceCards: 16,
+        citizenFaceCards: 0,
+      })
+    )
+    expect(napoleonOvershoot.napoleonNeedsToWin).toBe(0)
+
+    // 連合軍が阻止に必要な枚数を超えて取った場合
+    const allianceOvershoot = getGameProgress(
+      createGameState({
+        targetTricks: 13,
+        napoleonFaceCards: 0,
+        citizenFaceCards: 12,
+      })
+    )
+    expect(allianceOvershoot.allianceNeedsToWin).toBe(0)
+  })
+
+  it.each([
+    13,
+    15,
+    18,
+    NAPOLEON_RULES.TOTAL_FACE_CARDS,
+  ])('reports an alliance remaining count consistent with isGameDecided (target %i)', (targetTricks) => {
+    const blockingTotal = NAPOLEON_RULES.TOTAL_FACE_CARDS - targetTricks + 1
+    const alreadyWon = Math.max(0, blockingTotal - 2)
+
+    const state = createGameState({
+      targetTricks,
+      napoleonFaceCards: 0,
+      citizenFaceCards: alreadyWon,
+    })
+    const progress = getGameProgress(state)
+
+    // 不変条件: 残り枚数ちょうどを取れば阻止が確定し、1 枚足りなければ未確定
+    expect(progress.allianceNeedsToWin).toBeGreaterThan(0)
+
+    const oneShort = createGameState({
+      targetTricks,
+      napoleonFaceCards: 0,
+      citizenFaceCards: alreadyWon + progress.allianceNeedsToWin - 1,
+    })
+    expect(isGameDecided(oneShort).decided).toBe(false)
+
+    const exact = createGameState({
+      targetTricks,
+      napoleonFaceCards: 0,
+      citizenFaceCards: alreadyWon + progress.allianceNeedsToWin,
+    })
+    const decided = isGameDecided(exact)
+    expect(decided.decided).toBe(true)
+    expect(decided.napoleonWon).toBe(false)
+  })
+
+  it('shrinks the alliance remaining count as they take more face cards', () => {
+    const before = getGameProgress(
+      createGameState({
+        targetTricks: 15,
+        napoleonFaceCards: 0,
+        citizenFaceCards: 2,
+      })
+    )
+    const after = getGameProgress(
+      createGameState({
+        targetTricks: 15,
+        napoleonFaceCards: 0,
+        citizenFaceCards: 5,
+      })
+    )
+
+    expect(after.allianceNeedsToWin).toBe(before.allianceNeedsToWin - 3)
+  })
+})


### PR DESCRIPTION
## 何が見づらかったか

プレイ中に「あと何枚取れば / 阻止すればよいか」が盤面から追えませんでした。

宣言数が出ていたのは `TopHUD.tsx:52-77` の **`Face cards toward declaration (14)` という 10px 大文字ラベル内の括弧書き**だけ。目立たないうえ、残り枚数は暗算でした。

## 調査で判明したこと

**`GameStatus` の進捗バーはプレイ中に一度も描画されていません。** `src/app/game/[gameId]/page.tsx:461-598` が PLAYING 専用レイアウトで早期 return しており、`GameStatus`（691 行）と `CompactGameProgress`（660 行）は 601 行以降の**非 PLAYING 用**レイアウトにあります。

つまり `GameStatus.tsx` の `phase === PLAYING` でガードされたブロック（`Napoleon Face Card Progress` バー、`Face Cards Won by Player`）と `CompactGameProgress` は**実質デッドコード**です。今回は触っていません（下記「未対応」参照）。

## 変更

### 1. TopHUD の作り直し

レンダリング結果（宣言 15・ナポレオン 6 枚・連合軍 3 枚）:

```
♠ Napoleon │ Trick 9/12 │ [Declared 15 face cards] │ Face cards toward declaration  6 / 15
                                                     [███ yellow ██ blue ▏|        ]  ← | が宣言ライン
                                                     6 Napoleon · needs 9 more
                                                     3 Allied Forces · need 3 more
```

- **宣言数を独立チップに昇格。**トリック数と対等な位置、`text-xl` の黄色数字 + `face cards` の単位。既存の `bg-orange-500/20 border-orange-400/40` チップと同じ作りで、色は既存の yellow 系のみ
- **バーに宣言ラインのマーカー。**「どこまで伸びれば達成か」が視覚的に読める
- **残り枚数を両陣営分並記。**連合軍は獲得数ではなく阻止までの残り枚数
- 0 のときは `needs 0 more` ではなく `declaration met` / `declaration blocked`
- ハードコードの `13` / `20` / `12` を `NAPOLEON_RULES.TARGET_FACE_CARDS` / `TOTAL_FACE_CARDS` / `GAME_CONFIG.CARDS_PER_PLAYER` に置換

**視点による強調（自分の陣営だけ目立たせる）はあえて入れていません。** `maskGameState.ts:81` は公開前に**閲覧者自身も含め全員の `isAdjutant` を false にする**ため、副官本人を「連合軍」として強調してしまいます。両陣営の並記が正しい判断です。

### 2. ラベルの誤りを修正（3 ファイル）

`GameStatus.tsx:100-103` が宣言数の単位を **`tricks`** と表示していましたが、これは**絵札数**です（`types/game.ts:33`「取る予定の絵札数」、宣言フォームも「Target Face Cards (絵札数)」）。トリック数とは別物なので誤解の元でした。

**同じ誤りが `AdjutantSelector.tsx:167`（副官指定画面）にもありました。**`DeclarationDisplay.tsx:41` の直書き `'face cards'` も含めて `DECLARATION_LABELS` へ寄せ、単一ソースにしています。

### 3. `getGameProgress` に `allianceNeedsToWin` を追加（`src/lib/scoring.ts`）

連合軍視点の「あと何枚阻止すれば勝ちか」。`isGameDecided` の勝利条件（`citizen > TOTAL - target`）から逆算しており、**両者が食い違わないことをテストで突き合わせています**。

既存フィールドは不変です。**`targetTricks` のリネームはしていません**（DB に保存済みのデータと互換性が壊れるため）。

## テスト（新規 3 ファイル / 16 件）

- `scoring.declarationProgress.test.ts` — 数値の不変条件のみ。`allianceNeedsToWin` ちょうどで `isGameDecided` が確定し、1 枚足りないと未確定になることを target 13/15/18/20 で照合
- `TopHUD.declaration.test.tsx` — 「宣言 15・獲得 8 → 残り 7 が出る」型の不変条件。文言完全一致は使わず `needs\s+N\s+more` パターンと定数参照で検証
- `GameStatus.declarationLabel.test.tsx` — 宣言数を出す 3 コンポーネントで `/\btricks?\b/i` が出ないことを検証（回帰防止）

**空テストでないことを確認済み**: `scoring.ts` の `+ 1` を落とす変異で 2 スイート 6 件が失敗します。

`pnpm ci-check` exit 0（68 suites / 864 tests）。lint の警告 7 件はすべて既存・変更外です。

## 未対応

1. **デッドコードを残しました。**上記の `GameStatus` Progress / `Face Cards Won by Player` / `CompactGameProgress` は描画されません。`GameStatus.tsx:243` の `Napoleon Face Card Progress` という紛らわしい表記も残っています。削除は別途の判断が要ると考えスコープ外にしました
2. **実ブラウザでの表示は未検証です。**jsdom のレンダリング結果と Tailwind クラスの読みまでで、デスクトップ幅で HUD が 4 チップ + バーに収まるかの実測はしていません。`flex-wrap` があるので崩れないはずですが推測です
3. 公開前は副官の獲得絵札が連合軍側にカウントされる既存挙動（`getTeamFaceCardCounts` が masked な `isAdjutant` を見る）を、この表示も引き継いでいます

## #511 との関係

`GameStatus.tsx` と `src/lib/constants.ts` を #511 も編集しています（あちらは Teams ブロック 137-197 行と `BIDDING_LABELS`、こちらは 101-105 行と `DECLARATION_LABELS`）。領域は分けてありますが、**先にマージされた方に合わせて rebase が要る可能性があります。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- f142542 style: 新規テスト2ファイルを biome の整形結果に合わせる
- a09c5c3 refactor(ui): 描画されないコードを削除し、結果画面で副官が出ない問題を直す
- 0e68336 feat(ui): ナポレオンの宣言絵札数を盤面から読めるようにする

## 📁 Files Changed

**Total files changed: 12**

- 🔧 **Source Code**: 7 files
- 🧪 **Tests**: 5 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests

- `tests/components/game/GameStatus.adjutantRevealGate.test.tsx`
- `tests/components/game/GameStatus.declarationLabel.test.tsx`
- `tests/components/game/TopHUD.declaration.test.tsx`
- `tests/lib/scoring.declarationProgress.test.ts`
- `tests/components/game/GameStatus.solo-napoleon.test.tsx`

#### 📚 Documentation


#### 🔧 Source Code

- `src/app/game/[gameId]/page.tsx`
- `src/components/game/AdjutantSelector.tsx`
- `src/components/game/DeclarationDisplay.tsx`
- `src/components/game/GameStatus.tsx`
- `src/components/game/TopHUD.tsx`
- `src/lib/constants.ts`
- `src/lib/scoring.ts`

#### ⚙️ Configuration


#### 📄 Other Files


</details>

## 🏷️ Change Type

- 🧪 **Tests** - Test files modified/added
- 🎮 **Game Logic** - Core game functionality updated
- 💄 **UI/UX** - User interface improvements

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

## 🧪 Testing

Tests have been modified/added. Run the test suite:

```bash
npm test
npm run test:coverage
```

## 🚀 Local Testing

To test these changes locally:

```bash
git checkout feat/declaration-visibility
pnpm install
pnpm dev
# Visit http://localhost:3000
```

---

*🤖 This description was automatically generated from code changes*