### PR TITLE
chore(deps): Dependabot の Python 監視を pip から uv に切り替える

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,7 +83,26 @@ updates:
           - "patch"
 
   # Python (ML training: /python) の監視
-  - package-ecosystem: "pip"
+  #
+  # pip ではなく uv を使う。pip エコシステムは python/requirements.txt を
+  # 直接書き換えるが、このファイルは `uv export --no-hashes --no-dev` の
+  # 生成物であり、正は uv.lock である。生成物を独立に編集させると 2 つ壊れる。
+  #
+  # 1. uv.lock と必ずズレる。#509 で `uv sync --locked` の検証を入れるまで、
+  #    この不整合は CI をすり抜けていた（CI は uv.lock しか見ておらず、
+  #    requirements.txt が pip で解決できるかを検証していなかった）。
+  # 2. 推移的依存のピンを単独で上げてしまう。tomlkit は gradio の、
+  #    pydantic-core は pydantic の依存であり、他の制約と両立しない版に
+  #    上げられる。実例として #520 は tomlkit を 0.15.1 に上げようとしたが、
+  #    gradio 6.22.0 は tomlkit<0.15.0 を要求するため解決不能だった。
+  #    まったく同じ組み合わせが Hugging Face Space の Docker ビルドを
+  #    ResolutionImpossible で落としており（#509 で修正）、Space は別リポジトリで
+  #    再デプロイ時にしかビルドされないため、発覚まで数か月かかっている。
+  #
+  # uv エコシステムなら pyproject.toml と uv.lock を一組で更新するので、
+  # どちらも起きない。requirements.txt は生成物として人手で追従させる
+  # （手順は python/README.md）。
+  - package-ecosystem: "uv"
     directory: "/python"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## なぜ

pip エコシステムは `python/requirements.txt` を**直接書き換えます**。しかしこのファイルは `uv export --no-hashes --no-dev` の**生成物**で、正は `uv.lock` です。生成物を独立に編集させると 2 つ壊れます。

**1. `uv.lock` と必ずズレる。** #509 で `uv sync --locked` の検証を入れるまで、この不整合は CI をすり抜けていました（CI は `uv.lock` しか見ておらず、`requirements.txt` が pip で解決できるかを一度も検証していなかった）。

**2. 推移的依存のピンを単独で上げてしまう。** `tomlkit` は `gradio` の、`pydantic-core` は `pydantic` の依存であり、他の制約と両立しない版に上げられます。

実例が今週出ました。**#520** は `tomlkit` を 0.15.1 に上げようとしましたが:

```
× No solution found when resolving dependencies:
  ╰─▶ Because gradio==6.22.0 depends on tomlkit>=0.12.0,<0.15.0 and
      you require gradio==6.22.0, we can conclude that you require
      tomlkit>=0.12.0,<0.15.0.
      And because you require tomlkit==0.15.1, we can conclude that your
      requirements are unsatisfiable.
```

**まったく同じ組み合わせが Hugging Face Space の Docker ビルドを `ResolutionImpossible` で落としていました**（#509 で修正）。Space は GitHub とは別リポジトリで再デプロイ時にしかビルドされないため、壊れてから発覚するまで数か月かかっています。#520 はクローズしました。

## 変更

`package-ecosystem` を `pip` → `uv` に変更。`cooldown`（7日 / major 14日）、グループ定義、ラベル、`commit-message`、`versioning-strategy` などの既存設定はそのまま維持しています。

uv エコシステムは `pyproject.toml` と `uv.lock` を**一組で**更新するので、上の 2 つはどちらも起きません。

## トレードオフ（重要）

**uv は `requirements.txt` を更新しません。**生成物だからです。そのため Dependabot の Python PR は #509 で入れた整合チェックで落ちます。

解消は 1 コマンドで、手順は CI のエラーメッセージが出力します。

```bash
cd python && uv export --no-hashes --no-dev --format requirements-txt -o requirements.txt
```

今日の #517（pandas）で実際にこの手順を踏み、`uv lock --check` 通過 / pip 解決 80 パッケージ / pytest 110 passed を確認しています。

**根治案（別途）**: `python/Dockerfile` が `uv.lock` から直接インストールするようにして、`requirements.txt` をリポジトリから消す。そうすれば真のソースが 1 つになり、整合チェック自体が不要になります。ただし Space のビルド構成に触るため、動作確認とセットで別 PR にすべきと判断しました。

## リスク

`package-ecosystem: "uv"` が現行の Dependabot で受け付けられなかった場合、リポジトリの Dependabot 設定ページにエラーが出ます。その場合はこの PR を revert してください。設定ファイルの構文自体は変えていないので、影響は Python の監視が止まるだけです。

## 確認

`pnpm ci-check` exit 0（71 suites / 889 tests）。この PR はワークフロー設定のみで、アプリケーションコードには触れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 **Auto-generated PR Summary**

## 📝 Changes Summary

### Recent Commits:
- 08def7b chore(deps): Dependabot の Python 監視を pip から uv に切り替える

## 📁 Files Changed

**Total files changed: 1**

- ⚙️ **Configuration**: 1 files

<details>
<summary>📋 Detailed File List</summary>

#### 🧪 Tests


#### 📚 Documentation


#### 🔧 Source Code


#### ⚙️ Configuration

- `.github/dependabot.yml`

#### 📄 Other Files


</details>

## 🏷️ Change Type

- ⚙️ **Configuration** - Build/tool configuration changes

## ✅ Review Checklist

- [ ] Code follows project conventions (Biome linting)
- [ ] TypeScript types are properly defined
- [ ] Tests are added/updated for new functionality
- [ ] Documentation is updated if necessary
- [ ] All CI checks pass
- [ ] Breaking changes are documented

---

*🤖 This description was automatically generated from code changes*